### PR TITLE
feat: 가계부 페이지 기본 레이아웃 구현

### DIFF
--- a/src/components/ledger-layout/LedgerLayoutHeader.vue
+++ b/src/components/ledger-layout/LedgerLayoutHeader.vue
@@ -1,0 +1,108 @@
+<script setup>
+import { useLedgerLayoutStore } from "@/stores/ledger";
+import { computed, ref } from "vue";
+import { useRoute } from "vue-router";
+
+const layoutStore = useLedgerLayoutStore();
+const route = useRoute();
+
+const title = computed(() => layoutStore.currentPage.title);
+const desc = computed(() => {
+  if (route.path === "/ledger/dashboard") {
+    return new Date().toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      weekday: "long",
+    });
+  }
+  return layoutStore.currentPage.desc;
+});
+
+const userName = ref("홍길동");
+</script>
+
+<template>
+  <div class="ledger-layout-header">
+    <div class="header-left">
+      <div class="title">{{ title }}</div>
+      <div class="desc">{{ desc }}</div>
+    </div>
+    <div class="header-right">
+      <div class="alarm">
+        <i class="fa-regular fa-bell"></i>
+      </div>
+      <div class="profile">
+        <div class="avatar">
+          <i class="fa-regular fa-user"></i>
+        </div>
+        <span>{{ userName }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ledger-layout-header {
+  display: flex;
+  flex: 0 auto;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  padding: 8px 16px;
+}
+
+.header-left {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: start;
+  align-items: start;
+  gap: 4px;
+}
+
+.header-left .title {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.header-left .desc {
+  font-size: 14px;
+  color: #8ea2b7;
+}
+
+.header-right {
+  display: flex;
+  flex: 0 auto;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  gap: 24px;
+  padding: 0 8px;
+}
+
+.header-right .alarm {
+}
+
+.header-right .profile {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.header-right .profile .avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  color: #00c78b;
+  background-color: #00c78b64;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header-right .profile span {
+  font-size: 14px;
+}
+</style>

--- a/src/components/ledger-layout/LedgerLayoutSidebar.vue
+++ b/src/components/ledger-layout/LedgerLayoutSidebar.vue
@@ -1,0 +1,181 @@
+<script setup>
+import { useLedgerLayoutStore } from "@/stores/ledger";
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+
+const layoutStore = useLedgerLayoutStore();
+
+const route = useRoute();
+
+const open = computed(() => layoutStore.menuOpen);
+
+const sidebarClass = computed(() => {
+  return {
+    open: open.value,
+  };
+});
+
+const toggleSidebar = () => {
+  layoutStore.toggleMenu();
+};
+</script>
+
+<template>
+  <div class="sidebar" :class="sidebarClass">
+    <div class="header">
+      <img alt="" />
+      <span class="sidebar-label">Moneylog</span>
+    </div>
+    <div class="nav-bar">
+      <div
+        class="nav-item"
+        :class="navItem.to.path === route.path ? 'active' : ''"
+        v-for="navItem in layoutStore.pages"
+        :key="navItem.id"
+      >
+        <router-link :to="navItem.to">
+          <i :class="navItem.icon"></i
+          ><span class="sidebar-label">{{ navItem.title }}</span>
+        </router-link>
+      </div>
+    </div>
+    <div class="toggle-sidebar-box" @click="toggleSidebar">
+      <i
+        :class="!open ? 'fa-solid fa-angle-left' : 'fa-solid fa-angle-right'"
+      ></i>
+      <button class="sidebar-label toggle-sidebar-text">접기</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  align-items: stretch;
+  gap: 4px;
+  width: 240px;
+  border-right: 1px solid lightgray;
+  background-color: #141e2b;
+  overflow: hidden;
+  transition: width 0.3s ease;
+}
+
+.sidebar.open {
+  width: 64px;
+}
+
+.header {
+  flex: 0 auto;
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  gap: 16px;
+  height: 40px;
+  padding: 8px;
+  color: white;
+}
+
+.header > img {
+  flex: 0 auto;
+  width: 40px;
+  height: 40px;
+}
+
+.header > span {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.sidebar.open .header,
+.sidebar.open .nav-item a,
+.sidebar.open .toggle-sidebar-box {
+  justify-content: center;
+  gap: 0;
+}
+
+.sidebar-label {
+  white-space: nowrap;
+  overflow: hidden;
+  min-width: 0;
+  transition: opacity 0.2s ease 0.15s;
+}
+
+.sidebar.open .sidebar-label {
+  flex: 0 0 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.nav-bar {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
+  align-items: stretch;
+  gap: 4px;
+  padding: 8px;
+  border-top: 1px solid #8ea2b739;
+  border-bottom: 1px solid #8ea2b739;
+}
+
+.nav-item {
+  flex: 0 auto;
+  height: 32px;
+  padding: 8px;
+  border-radius: 16px;
+}
+
+.nav-item * {
+  text-decoration: none;
+  color: #8ea2b7;
+}
+
+.nav-item a {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  height: 100%;
+}
+
+.nav-item i {
+  flex: 0 0 32px;
+  text-align: center;
+}
+
+.nav-item span {
+  flex: 1 1 auto;
+}
+
+.nav-item.active {
+  background-color: #00bc7d40;
+}
+
+.nav-item.active * {
+  color: #00c78b;
+}
+
+.toggle-sidebar-box {
+  flex: 0 auto;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  height: 60px;
+}
+
+.toggle-sidebar-box * {
+  color: #8ea2b7;
+}
+
+.toggle-sidebar-text {
+  background: none;
+  border: none;
+  padding: 0;
+}
+</style>

--- a/src/layouts/LedgerLayout.vue
+++ b/src/layouts/LedgerLayout.vue
@@ -1,0 +1,57 @@
+<script setup>
+import LedgerLayoutHeader from "@/components/ledger-layout/LedgerLayoutHeader.vue";
+import LedgerLayoutSidebar from "@/components/ledger-layout/LedgerLayoutSidebar.vue";
+</script>
+
+<template>
+  <div class="layout">
+    <LedgerLayoutSidebar />
+    <div class="content">
+      <LedgerLayoutHeader />
+      <div class="body">
+        <router-view></router-view>
+      </div>
+    </div>
+    <button class="add-transaction-btn">
+      <i class="fa-solid fa-plus"></i>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.layout {
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  width: 100%;
+  height: 100vh;
+}
+
+.content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  justify-content: start;
+}
+
+.body {
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+}
+
+.add-transaction-btn {
+  position: fixed;
+  width: 64px;
+  height: 64px;
+  bottom: 32px;
+  right: 32px;
+  border: none;
+  border-radius: 50%;
+  box-shadow:
+    0 4px 8px 0 rgba(0, 0, 0, 0.2),
+    0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  transition: background-color 0.3s ease;
+  background-color: #00bc7c;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,6 +19,8 @@ const router = createRouter({
     },
     {
       path: "/ledger",
+      component: () => import("@/layouts/LedgerLayout.vue"),
+      redirect: "/ledger/dashboard",
       children: [
         {
           path: "dashboard",

--- a/src/stores/ledger.js
+++ b/src/stores/ledger.js
@@ -1,0 +1,50 @@
+import { defineStore } from "pinia";
+import { ref, computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+export const useLedgerLayoutStore = defineStore("ledger-layout", () => {
+  const pages = [
+    {
+      to: { path: "/ledger/dashboard" },
+      icon: "fa-solid fa-house",
+      title: "홈",
+    },
+    {
+      to: { path: "/ledger/mypage" },
+      icon: "fa-solid fa-user",
+      title: "마이페이지",
+      desc: "내 정보와 설정을 관리하세요",
+    },
+    {
+      to: { path: "/ledger/transactions" },
+      icon: "fa-solid fa-left-right",
+      title: "거래내역",
+      desc: "수입과 지출 내역을 조회하고 관리하세요",
+    },
+    {
+      to: { path: "/ledger/stat" },
+      icon: "fa-solid fa-chart-simple",
+      title: "통계",
+      desc: "수입과 지출 패턴을 분석하세요",
+    },
+  ];
+
+  const route = useRoute();
+  const menuOpen = ref(false);
+
+  const currentPage = computed(() => {
+    const page = pages.find((page) => page.to.path === route.path);
+    return { ...page };
+  });
+
+  const toggleMenu = () => {
+    menuOpen.value = !menuOpen.value;
+  };
+
+  return {
+    pages: computed(() => structuredClone(pages)),
+    menuOpen: computed(() => menuOpen.value),
+    currentPage,
+    toggleMenu,
+  };
+});


### PR DESCRIPTION
#️⃣ 연관된 이슈

- close: #2 

✨ 작업 내용

- router/index.js : LedgerLayout을 ledger 기본 페이지 컴포넌트로 지정했습니다. 하위 path에 따라 LedgerLayout router-view로 직접 마운트됩니다.
- stores/ledger.js : useLedgerLayout 스토어를 이용해 Ledger의 레이아웃 상태를 관리하도록 구현했습니다.
- layouts/LedgerLayout.vue : ledger 라우트 기본 레이아웃을 구현했습니다.
- components/ledger-layout/* : LedgerLayout.vue에 사용하는 기본 컴포넌트를 구현했습니다.

💖 리뷰 요청사항

특별히 봐주셨으면 하는 부분, 기타 당부의 말씀 등 자유롭게 작성해주세요.