### PR TITLE
fix: 레이아웃 사이즈 버그 해결

### DIFF
--- a/src/components/ledger-layout/LedgerLayoutHeader.vue
+++ b/src/components/ledger-layout/LedgerLayoutHeader.vue
@@ -45,7 +45,7 @@ const userName = ref("홍길동");
 <style scoped>
 .ledger-layout-header {
   display: flex;
-  flex: 0 auto;
+  flex: 0 0 auto;
   flex-direction: row;
   justify-content: start;
   align-items: center;
@@ -73,7 +73,7 @@ const userName = ref("홍길동");
 
 .header-right {
   display: flex;
-  flex: 0 auto;
+  flex: 0 0 auto;
   flex-direction: row;
   justify-content: start;
   align-items: center;

--- a/src/components/ledger-layout/LedgerLayoutSidebar.vue
+++ b/src/components/ledger-layout/LedgerLayoutSidebar.vue
@@ -51,6 +51,7 @@ const toggleSidebar = () => {
 <style scoped>
 .sidebar {
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
   justify-content: start;
   align-items: stretch;
@@ -67,7 +68,7 @@ const toggleSidebar = () => {
 }
 
 .header {
-  flex: 0 auto;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: row;
   justify-content: start;
@@ -79,7 +80,7 @@ const toggleSidebar = () => {
 }
 
 .header > img {
-  flex: 0 auto;
+  flex: 0 0 auto;
   width: 40px;
   height: 40px;
 }
@@ -123,7 +124,7 @@ const toggleSidebar = () => {
 }
 
 .nav-item {
-  flex: 0 auto;
+  flex: 0 0 auto;
   height: 32px;
   padding: 8px;
   border-radius: 16px;
@@ -161,7 +162,7 @@ const toggleSidebar = () => {
 }
 
 .toggle-sidebar-box {
-  flex: 0 auto;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/src/layouts/LedgerLayout.vue
+++ b/src/layouts/LedgerLayout.vue
@@ -32,11 +32,14 @@ import LedgerLayoutSidebar from "@/components/ledger-layout/LedgerLayoutSidebar.
   flex: 1 1 auto;
   flex-direction: column;
   justify-content: start;
+  max-width: 100%;
+  max-height: 100%;
+  overflow: hidden;
 }
 
 .body {
-  width: 100%;
-  height: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close: #22

## ✨ 작업 내용

- [x] LedgerLayout 내부 뷰 사이즈 버그 수정 : 내부 뷰에 오버플로우 발생 시 사이드바, 헤더 사이즈가 영향을 받지 않고 스크롤바만 처리됩니다.
