### PR TITLE
style: 통계 페이지 공통 테마 색상 및 카테고리 아이콘 적용

### DIFF
--- a/src/components/statistic/MainChart.vue
+++ b/src/components/statistic/MainChart.vue
@@ -68,8 +68,8 @@ const chartData = computed(() => {
         label: '순이익',
         type: 'line',
         data: data.profits,
-        borderColor: '#20bf6b',
-        backgroundColor: '#20bf6b',
+        borderColor: '#28c76f',
+        backgroundColor: '#28c76f',
         tension: 0.4,
         pointRadius: 4,
         fill: false,
@@ -79,7 +79,7 @@ const chartData = computed(() => {
         label: '수입',
         type: 'bar',
         data: data.incomes,
-        backgroundColor: '#00a8ff',
+        backgroundColor: '#00cfe8',
         borderRadius: 6,
         barPercentage: 0.5,
       },
@@ -87,7 +87,7 @@ const chartData = computed(() => {
         label: '지출',
         type: 'bar',
         data: data.expenses,
-        backgroundColor: '#ff4d4d',
+        backgroundColor: '#ea5455',
         borderRadius: 6,
         barPercentage: 0.5,
       },
@@ -220,17 +220,17 @@ h3 {
 }
 
 .data-row.income strong {
-  color: #00a8ff;
+  color: #00cfe8;
 }
 .data-row.expense strong {
-  color: #ff4d4d;
+  color: #ea5455;
 }
 .data-row.profit {
   font-size: 1.1rem;
   margin-top: 16px;
 }
 .data-row.profit strong {
-  color: #20bf6b;
+  color: #28c76f;
 }
 hr {
   border: none;

--- a/src/components/statistic/SummaryCard.vue
+++ b/src/components/statistic/SummaryCard.vue
@@ -33,9 +33,9 @@ const diffClass = computed(() => (props.diff >= 0 ? 'up' : 'down'));
   <div class="summary-card">
     <div class="card-header">
       <span class="icon-wrapper" :class="type">
-        <i v-if="type === 'income'">💰</i>
-        <i v-else-if="type === 'expense'">💸</i>
-        <i v-else>📊</i>
+        <i v-if="type === 'income'" class="fa-solid fa-arrow-down"></i>
+        <i v-else-if="type === 'expense'" class="fa-solid fa-arrow-up"></i>
+        <i v-else class="fa-solid fa-arrow-right-arrow-left"></i>
       </span>
       <span class="title">{{ title }}</span>
     </div>
@@ -81,13 +81,16 @@ const diffClass = computed(() => (props.diff >= 0 ? 'up' : 'down'));
   font-size: 1.2rem;
 }
 .icon-wrapper.income {
-  background: #e3f2fd;
+  background: #e0f2fe;
+  color: #00cfe8;
 }
 .icon-wrapper.expense {
-  background: #ffebee;
+  background: #fceaea;
+  color: #ea5455;
 }
 .icon-wrapper.profit {
-  background: #e8f5e9;
+  background: #e6f7ef;
+  color: #28c76f;
 }
 
 .title {
@@ -103,13 +106,13 @@ const diffClass = computed(() => (props.diff >= 0 ? 'up' : 'down'));
 }
 
 .text-blue {
-  color: #2d98da;
+  color: #00cfe8;
 }
 .text-red {
-  color: #eb4d4b;
+  color: #ea5455;
 }
 .text-green {
-  color: #20bf6b;
+  color: #28c76f;
 }
 
 .comparison {
@@ -119,11 +122,11 @@ const diffClass = computed(() => (props.diff >= 0 ? 'up' : 'down'));
 }
 
 .up {
-  color: #eb4d4b;
+  color: #ea5455;
   font-weight: 600;
 }
 .down {
-  color: #2d98da;
+  color: #00cfe8;
   font-weight: 600;
 }
 </style>

--- a/src/components/statistic/TopCategoryList.vue
+++ b/src/components/statistic/TopCategoryList.vue
@@ -37,7 +37,12 @@ const calculateWidth = (amount) => {
 
         <div class="rank-info">
           <div class="category-meta">
-            <span class="icon">{{ item.icon }}</span>
+            <div
+              class="icon-wrapper"
+              :style="{ backgroundColor: item.color + '1A', color: item.color }"
+            >
+              <i :class="item.icon"></i>
+            </div>
             <span class="rank-name">{{ item.name }}</span>
           </div>
           <div class="progress-bar">
@@ -100,8 +105,17 @@ const calculateWidth = (amount) => {
 .category-meta {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   margin-bottom: 6px;
+}
+.icon-wrapper {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
 }
 .rank-name {
   font-size: 0.95rem;
@@ -128,10 +142,10 @@ const calculateWidth = (amount) => {
   font-size: 0.95rem;
 }
 .amount-val.expense {
-  color: #eb4d4b;
+  color: #ea5455;
 }
 .amount-val.income {
-  color: #2d98da;
+  color: #00cfe8;
 }
 .count-val {
   font-size: 0.75rem;

--- a/src/composables/useCategoryStats.js
+++ b/src/composables/useCategoryStats.js
@@ -1,6 +1,7 @@
 import { computed, toValue } from 'vue';
 import { useTransactionStore } from '@/stores/useTransactionStore';
 import { storeToRefs } from 'pinia';
+import { Categories } from '@/constant/categories';
 
 export function useCategoryStats(activeTypeRef) {
   const store = useTransactionStore();
@@ -28,12 +29,17 @@ export function useCategoryStats(activeTypeRef) {
       const category = categories.value.find(
         (c) => String(c.id) === String(catId),
       );
+
+      const staticCategory = Object.values(Categories).find(
+        (c) => String(c.id) === String(catId),
+      );
+
       return {
         name: category ? category.name : '기타',
         amount: categoryMap[catId].amount,
         count: categoryMap[catId].count,
-        color: category ? category.color : '#ccc',
-        icon: category?.label === 'INCOME' ? '💰' : '💸',
+        color: category?.color || '#ccc',
+        icon: staticCategory?.icon || 'fa-solid fa-tag',
       };
     });
 

--- a/src/views/ledger/Statistic.vue
+++ b/src/views/ledger/Statistic.vue
@@ -134,9 +134,9 @@ watch(currentFilter, (newVal) => {
 }
 
 .filter-btn.active {
-  background-color: #20bf6b;
+  background-color: #28c76f;
   color: white;
-  border-color: #20bf6b;
+  border-color: #28c76f;
   font-weight: bold;
 }
 
@@ -162,12 +162,12 @@ watch(currentFilter, (newVal) => {
 }
 
 .toggle-btn.active {
-  background: #ff5252;
+  background: #ea5455;
   color: white;
 }
 
 .toggle-btn:nth-child(2).active {
-  background: #20bf6b;
+  background: #00cfe8;
 }
 
 .bottom-container {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close: #55 

## ✨ 작업 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- [x] 기능 추가
- [ ] 버그 수정

**세부 작업 내용**
- `categories.js` 상수를 연동하여 `TopCategoryList`에 각 카테고리별 고유 아이콘 및 색상 렌더링 적용
- `SummaryCard` 내의 임시 이모지(💰, 💸 등)를 직관적인 FontAwesome 화살표 아이콘으로 교체
- 수입(파랑), 지출(빨강), 순이익(초록) 테마 컬러를 `MainChart`, `SummaryCard`, 기간 필터 토글 버튼 등 통계 페이지 전반에 일관되게 적용
- `useCategoryStats` 컴포저블 내 아이콘 및 색상 매핑 로직 개선

## 💖 리뷰 요청사항
