### PR TITLE
feat: 차트 렌더링을 위한 데이터 가공 로직, 카테고리 코드 분리

### DIFF
--- a/src/api/axiosClient.js
+++ b/src/api/axiosClient.js
@@ -1,12 +1,12 @@
-import axios from "axios";
+import axios from 'axios';
 import {
   FetchFailedError,
   NetworkOfflineError,
   SaveFailedError,
-} from "./networkError";
-import { ErrorCode } from "@/constant/errorCode";
+} from './networkError';
+import { ErrorCode } from '@/constant/errorCode';
 
-const urlPrefix = "/api";
+const urlPrefix = '/api';
 
 const isRequestSuccessful = (statusCode) => {
   return statusCode >= 200 && statusCode < 300;
@@ -44,9 +44,7 @@ async function getMembers() {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const members = res.data;
-
-  return members;
+  return res.data;
 }
 
 async function getMember(memberId) {
@@ -54,9 +52,7 @@ async function getMember(memberId) {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const member = res.data;
-
-  return member;
+  return res.data;
 }
 
 async function getMemberByEmail(email) {
@@ -64,9 +60,7 @@ async function getMemberByEmail(email) {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const members = res.data;
-
-  return members;
+  return res.data;
 }
 
 async function createMember(member) {
@@ -74,9 +68,7 @@ async function createMember(member) {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const createdMember = res.data;
-
-  return createdMember;
+  return res.data;
 }
 
 async function updateMember(memberId, member) {
@@ -84,9 +76,7 @@ async function updateMember(memberId, member) {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const updatedMember = res.data;
-
-  return updatedMember;
+  return res.data;
 }
 
 async function deleteMember(memberId) {
@@ -100,9 +90,7 @@ async function getTransactions() {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const transactions = res.data;
-
-  return transactions;
+  return res.data;
 }
 
 async function getTransaction(transactionId) {
@@ -110,17 +98,13 @@ async function getTransaction(transactionId) {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const transaction = res.data;
-
-  return transaction;
+  return res.data;
 }
 
 async function getTransactionsByUserId(userId) {
   const res = await axios.get(`${urlPrefix}/transactions?user_id:eq=${userId}`);
 
-  const transactions = res.data;
-
-  return transactions;
+  return res.data;
 }
 
 async function createTransaction(transaction) {
@@ -128,9 +112,7 @@ async function createTransaction(transaction) {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const createdTransaction = res.data;
-
-  return createdTransaction;
+  return res.data;
 }
 
 async function updateTransaction(transactionId, transaction) {
@@ -141,9 +123,7 @@ async function updateTransaction(transactionId, transaction) {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const updatedTransaction = res.data;
-
-  return updatedTransaction;
+  return res.data;
 }
 
 async function deleteTransaction(transactionId) {
@@ -157,9 +137,7 @@ async function getCategories() {
 
   checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
-  const categories = res.data;
-
-  return categories;
+  return res.data;
 }
 
 const memberApi = {

--- a/src/components/statistic/CategoryChart.vue
+++ b/src/components/statistic/CategoryChart.vue
@@ -10,27 +10,8 @@ const props = defineProps({
   activeType: String,
 });
 
-const { aggregatedStats } = useCategoryStats(() => props.activeType);
-
-const processedData = computed(() => {
-  if (aggregatedStats.value.length === 0) {
-    return { labels: [], values: [], colors: [], count: 0 };
-  }
-
-  const totalSum = aggregatedStats.value.reduce(
-    (sum, item) => sum + item.amount,
-    0,
-  );
-
-  return {
-    labels: aggregatedStats.value.map((r) => r.name),
-    values: aggregatedStats.value.map((r) =>
-      totalSum > 0 ? ((r.amount / totalSum) * 100).toFixed(1) : 0,
-    ),
-    colors: aggregatedStats.value.map((r) => r.color),
-    count: aggregatedStats.value.length,
-  };
-});
+// 데이터 가공 로직을 훅 내부로 이동시켜 컴포넌트 단순화
+const { processedData } = useCategoryStats(() => props.activeType);
 
 const chartData = computed(() => ({
   labels: processedData.value.labels,

--- a/src/composables/useCategoryStats.js
+++ b/src/composables/useCategoryStats.js
@@ -1,7 +1,8 @@
 import { computed, toValue } from 'vue';
 import { useTransactionStore } from '@/stores/useTransactionStore';
 import { storeToRefs } from 'pinia';
-import { Categories } from '@/constant/categories';
+import { getCategoryById } from '@/constant/categories';
+import { calculatePercent } from '@/utils/formatter';
 
 export function useCategoryStats(activeTypeRef) {
   const store = useTransactionStore();
@@ -13,38 +14,52 @@ export function useCategoryStats(activeTypeRef) {
     }
 
     const typeKey = toValue(activeTypeRef).toUpperCase();
-    const categoryMap = {};
 
-    thisMonthTransactions.value.forEach((t) => {
-      if (t.type === typeKey) {
-        if (!categoryMap[t.category_id]) {
-          categoryMap[t.category_id] = { amount: 0, count: 0 };
+    const categoryMap = thisMonthTransactions.value
+      .filter((t) => t.type === typeKey)
+      .reduce((acc, t) => {
+        if (!acc[t.category_id]) {
+          acc[t.category_id] = { amount: 0, count: 0 };
         }
-        categoryMap[t.category_id].amount += t.amount;
-        categoryMap[t.category_id].count += 1;
-      }
-    });
+        acc[t.category_id].amount += t.amount;
+        acc[t.category_id].count += 1;
+        return acc;
+      }, {});
 
-    const result = Object.keys(categoryMap).map((catId) => {
-      const category = categories.value.find(
-        (c) => String(c.id) === String(catId),
-      );
+    return Object.entries(categoryMap)
+      .map(([catId, stats]) => {
+        const category = categories.value.find(
+          (c) => String(c.id) === String(catId),
+        );
 
-      const staticCategory = Object.values(Categories).find(
-        (c) => String(c.id) === String(catId),
-      );
+        const staticCategory = getCategoryById(catId);
 
-      return {
-        name: category ? category.name : '기타',
-        amount: categoryMap[catId].amount,
-        count: categoryMap[catId].count,
-        color: category?.color || '#ccc',
-        icon: staticCategory?.icon || 'fa-solid fa-tag',
-      };
-    });
-
-    return result.sort((a, b) => b.amount - a.amount);
+        return {
+          name: category ? category.name : '기타',
+          amount: stats.amount,
+          count: stats.count,
+          color: category?.color || '#ccc',
+          icon: staticCategory?.icon || 'fa-solid fa-tag',
+        };
+      })
+      .sort((a, b) => b.amount - a.amount);
   });
 
-  return { aggregatedStats };
+  const processedData = computed(() => {
+    const stats = aggregatedStats.value;
+    if (stats.length === 0) {
+      return { labels: [], values: [], colors: [], count: 0 };
+    }
+
+    const totalSum = stats.reduce((sum, item) => sum + item.amount, 0);
+
+    return {
+      labels: stats.map((r) => r.name),
+      values: stats.map((r) => calculatePercent(r.amount, totalSum)),
+      colors: stats.map((r) => r.color),
+      count: stats.length,
+    };
+  });
+
+  return { aggregatedStats, processedData };
 }

--- a/src/constant/categories.js
+++ b/src/constant/categories.js
@@ -1,125 +1,130 @@
 export const Categories = {
   // 1. 지출 카테고리 (EXPENSE)
   FOOD: {
-    id: "cat01",
-    name: "식비",
-    label: "EXPENSE",
-    color: "#FF6B00", // 이미지에서 추출한 주황색
-    subColor: "#FFD700", // 보조: 밝은 노랑/주황
-    icon: "fa-solid fa-utensils",
+    id: 'cat01',
+    name: '식비',
+    label: 'EXPENSE',
+    color: '#FF6B00', // 이미지에서 추출한 주황색
+    subColor: '#FFD700', // 보조: 밝은 노랑/주황
+    icon: 'fa-solid fa-utensils',
   },
   CAFE: {
-    id: "cat02",
-    name: "카페",
-    label: "EXPENSE",
-    color: "#FFD979", // 이미지에서 추출한 연노랑
-    subColor: "#FFFACD", // 보조: 크림색
-    icon: "fa-solid fa-mug-hot",
+    id: 'cat02',
+    name: '카페',
+    label: 'EXPENSE',
+    color: '#FFD979', // 이미지에서 추출한 연노랑
+    subColor: '#FFFACD', // 보조: 크림색
+    icon: 'fa-solid fa-mug-hot',
   },
   TRANSPORT: {
-    id: "cat03",
-    name: "교통",
-    label: "EXPENSE",
-    color: "#00BFFF", // 이미지에서 추출한 하늘색
-    subColor: "#B0E0E6", // 보조: 파우더 블루
-    icon: "fa-solid fa-bus",
+    id: 'cat03',
+    name: '교통',
+    label: 'EXPENSE',
+    color: '#00BFFF', // 이미지에서 추출한 하늘색
+    subColor: '#B0E0E6', // 보조: 파우더 블루
+    icon: 'fa-solid fa-bus',
   },
   SHOPPING: {
-    id: "cat04",
-    name: "쇼핑",
-    label: "EXPENSE",
-    color: "#FF0000", // 이미지에서 추출한 빨간색
-    subColor: "#FFB6C1", // 보조: 핑크색
-    icon: "fa-solid fa-bag-shopping",
+    id: 'cat04',
+    name: '쇼핑',
+    label: 'EXPENSE',
+    color: '#FF0000', // 이미지에서 추출한 빨간색
+    subColor: '#FFB6C1', // 보조: 핑크색
+    icon: 'fa-solid fa-bag-shopping',
   },
   GROCERIES: {
-    id: "cat05",
-    name: "식료품",
-    label: "EXPENSE",
-    color: "#D2691E", // 이미지에서 추출한 진한 주황색
-    subColor: "#F4A460", // 보조: 샌디 브라운
-    icon: "fa-solid fa-basket-shopping",
+    id: 'cat05',
+    name: '식료품',
+    label: 'EXPENSE',
+    color: '#D2691E', // 이미지에서 추출한 진한 주황색
+    subColor: '#F4A460', // 보조: 샌디 브라운
+    icon: 'fa-solid fa-basket-shopping',
   },
   SUBSCRIPTION: {
-    id: "cat06",
-    name: "구독",
-    label: "EXPENSE",
-    color: "#9370DB", // 이미지에서 추출한 보라색
-    subColor: "#E6E6FA", // 보조: 라벤더
-    icon: "fa-solid fa-tv",
+    id: 'cat06',
+    name: '구독',
+    label: 'EXPENSE',
+    color: '#9370DB', // 이미지에서 추출한 보라색
+    subColor: '#E6E6FA', // 보조: 라벤더
+    icon: 'fa-solid fa-tv',
   },
   HEALTH: {
-    id: "cat07",
-    name: "건강",
-    label: "EXPENSE",
-    color: "#00FA9A", // 이미지에서 추출한 민트색
-    subColor: "#AFEEEE", // 보조: 팔레 터콰이즈
-    icon: "fa-solid fa-heartbeat",
+    id: 'cat07',
+    name: '건강',
+    label: 'EXPENSE',
+    color: '#00FA9A', // 이미지에서 추출한 민트색
+    subColor: '#AFEEEE', // 보조: 팔레 터콰이즈
+    icon: 'fa-solid fa-heartbeat',
   },
   EDUCATION: {
-    id: "cat08",
-    name: "교육",
-    label: "EXPENSE",
-    color: "#0000CD", // 이미지에서 추출한 진한 파란색
-    subColor: "#ADD8E6", // 보조: 라이트 블루
-    icon: "fa-solid fa-graduation-cap",
+    id: 'cat08',
+    name: '교육',
+    label: 'EXPENSE',
+    color: '#0000CD', // 이미지에서 추출한 진한 파란색
+    subColor: '#ADD8E6', // 보조: 라이트 블루
+    icon: 'fa-solid fa-graduation-cap',
   },
   LEISURE: {
-    id: "cat09",
-    name: "여가",
-    label: "EXPENSE",
-    color: "#9C88FF", // 이미지에서 추출한 연보라색
-    subColor: "#D8BFD8", // 보조: 시슬
-    icon: "fa-solid fa-gamepad",
+    id: 'cat09',
+    name: '여가',
+    label: 'EXPENSE',
+    color: '#9C88FF', // 이미지에서 추출한 연보라색
+    subColor: '#D8BFD8', // 보조: 시슬
+    icon: 'fa-solid fa-gamepad',
   },
   ETC_EXPENSE: {
-    id: "cat98",
-    name: "기타",
-    label: "EXPENSE",
-    color: "#808080", // 이미지에서 추출한 회색
-    subColor: "#D3D3D3", // 보조: 라이트 그레이
-    icon: "fa-solid fa-ellipsis-h",
+    id: 'cat98',
+    name: '기타',
+    label: 'EXPENSE',
+    color: '#808080', // 이미지에서 추출한 회색
+    subColor: '#D3D3D3', // 보조: 라이트 그레이
+    icon: 'fa-solid fa-ellipsis-h',
   },
 
   // 2. 수입 카테고리 (INCOME)
   SALARY: {
-    id: "cat10",
-    name: "급여",
-    label: "INCOME",
-    color: "#1E90FF", // 이미지에서 추출한 파란색
-    subColor: "#87CEFA", // 보조: 라이트 스카이 블루
-    icon: "fa-solid fa-money-check-dollar",
+    id: 'cat10',
+    name: '급여',
+    label: 'INCOME',
+    color: '#1E90FF', // 이미지에서 추출한 파란색
+    subColor: '#87CEFA', // 보조: 라이트 스카이 블루
+    icon: 'fa-solid fa-money-check-dollar',
   },
   SIDE_JOB: {
-    id: "cat11",
-    name: "부업",
-    label: "INCOME",
-    color: "#00CED1", // 이미지에서 추출한 청록색
-    subColor: "#AFEEEE", // 보조: 팔레 터콰이즈
-    icon: "fa-solid fa-briefcase",
+    id: 'cat11',
+    name: '부업',
+    label: 'INCOME',
+    color: '#00CED1', // 이미지에서 추출한 청록색
+    subColor: '#AFEEEE', // 보조: 팔레 터콰이즈
+    icon: 'fa-solid fa-briefcase',
   },
   INVESTMENT: {
-    id: "cat12",
-    name: "투자",
-    label: "INCOME",
-    color: "#008000", // 이미지에서 추출한 녹색
-    subColor: "#90EE90", // 보조: 라이트 그린
-    icon: "fa-solid fa-chart-line",
+    id: 'cat12',
+    name: '투자',
+    label: 'INCOME',
+    color: '#008000', // 이미지에서 추출한 녹색
+    subColor: '#90EE90', // 보조: 라이트 그린
+    icon: 'fa-solid fa-chart-line',
   },
   ALLOWANCE: {
-    id: "cat13",
-    name: "용돈",
-    label: "INCOME",
-    color: "#7FFF00", // 이미지에서 추출한 연녹색
-    subColor: "#F0FFF0", // 보조: 허니듀
-    icon: "fa-solid fa-piggy-bank",
+    id: 'cat13',
+    name: '용돈',
+    label: 'INCOME',
+    color: '#7FFF00', // 이미지에서 추출한 연녹색
+    subColor: '#F0FFF0', // 보조: 허니듀
+    icon: 'fa-solid fa-piggy-bank',
   },
   ETC_INCOME: {
-    id: "cat99",
-    name: "기타",
-    label: "INCOME",
-    color: "#808080", // 이미지에서 추출한 회색
-    subColor: "#D3D3D3", // 보조: 라이트 그레이
-    icon: "fa-solid fa-ellipsis-h",
+    id: 'cat99',
+    name: '기타',
+    label: 'INCOME',
+    color: '#808080', // 이미지에서 추출한 회색
+    subColor: '#D3D3D3', // 보조: 라이트 그레이
+    icon: 'fa-solid fa-ellipsis-h',
   },
+};
+
+// ID로 카테고리 정보를 쉽게 찾기 위한 유틸리티 함수
+export const getCategoryById = (id) => {
+  return Object.values(Categories).find((c) => String(c.id) === String(id));
 };

--- a/src/stores/useTransactionStore.js
+++ b/src/stores/useTransactionStore.js
@@ -1,9 +1,9 @@
-import { defineStore } from "pinia";
-import { ref, computed } from "vue";
-import axiosClient from "@/api/axiosClient";
-import { useAuthStore } from "./auth/useAuthStore";
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import axiosClient from '@/api/axiosClient';
+import { useAuthStore } from './auth/useAuthStore';
 
-export const useTransactionStore = defineStore("transaction", () => {
+export const useTransactionStore = defineStore('transaction', () => {
   // state
   const transactions = ref([]);
   const categories = ref([]);
@@ -18,13 +18,18 @@ export const useTransactionStore = defineStore("transaction", () => {
     };
   });
 
+  // 날짜 필터링 헬퍼 함수
+  const filterByMonthYear = (list, targetMonth, targetYear) => {
+    return list.filter((t) => {
+      const d = new Date(t.transacted_at);
+      return d.getMonth() === targetMonth && d.getFullYear() === targetYear;
+    });
+  };
+
   // 이번 달 거래 내역
   const thisMonthTransactions = computed(() => {
     const { month, year } = getDateInfo.value;
-    return transactions.value.filter((t) => {
-      const d = new Date(t.transacted_at);
-      return d.getMonth() === month && d.getFullYear() === year;
-    });
+    return filterByMonthYear(transactions.value, month, year);
   });
 
   // 지난달 거래 내역
@@ -32,10 +37,7 @@ export const useTransactionStore = defineStore("transaction", () => {
     const { month, year } = getDateInfo.value;
     const lastM = month === 0 ? 11 : month - 1;
     const lastY = month === 0 ? year - 1 : year;
-    return transactions.value.filter((t) => {
-      const d = new Date(t.transacted_at);
-      return d.getMonth() === lastM && d.getFullYear() === lastY;
-    });
+    return filterByMonthYear(transactions.value, lastM, lastY);
   });
 
   // 요약 데이터 계산용 헬퍼
@@ -48,12 +50,12 @@ export const useTransactionStore = defineStore("transaction", () => {
 
     const stats = {
       income: {
-        current: calculateTotal(tMonth, "INCOME"),
-        last: calculateTotal(lMonth, "INCOME"),
+        current: calculateTotal(tMonth, 'INCOME'),
+        last: calculateTotal(lMonth, 'INCOME'),
       },
       expense: {
-        current: calculateTotal(tMonth, "EXPENSE"),
-        last: calculateTotal(lMonth, "EXPENSE"),
+        current: calculateTotal(tMonth, 'EXPENSE'),
+        last: calculateTotal(lMonth, 'EXPENSE'),
       },
     };
 
@@ -80,17 +82,21 @@ export const useTransactionStore = defineStore("transaction", () => {
       const authStore = useAuthStore();
       if (!authStore.isLoggedIn) {
         transactions.value = [];
+        categories.value = []; // 로그아웃 시 카테고리도 초기화
         return;
       }
       const userId = authStore.user.id;
 
-      const transactionsData =
-        await axiosClient.transactionApi.getTransactionsByUserId(userId);
-      console.log(transactionsData);
+      // Promise.all을 사용하여 트랜잭션과 카테고리 데이터를 병렬로 가져옴
+      const [transactionsData, categoriesData] = await Promise.all([
+        axiosClient.transactionApi.getTransactionsByUserId(userId),
+        axiosClient.categoryApi.getCategories(),
+      ]);
 
       transactions.value = transactionsData;
+      categories.value = categoriesData;
     } catch (error) {
-      console.error("Data Fetch Error:", error);
+      console.error('Data Fetch Error:', error);
     } finally {
       loading.value = false;
     }
@@ -106,7 +112,7 @@ export const useTransactionStore = defineStore("transaction", () => {
         await axiosClient.transactionApi.deleteTransaction(id);
       } catch (error) {
         transactions.value.splice(index, 0, backup);
-        alert("삭제에 실패했습니다.");
+        alert('삭제에 실패했습니다.');
       }
     }
   }
@@ -123,8 +129,8 @@ export const useTransactionStore = defineStore("transaction", () => {
       }
       return true;
     } catch (error) {
-      console.error("거래 추가 실패:", error);
-      alert("거래 내역을 추가하는데 실패했습니다.");
+      console.error('거래 추가 실패:', error);
+      alert('거래 내역을 추가하는데 실패했습니다.');
       return false;
     }
   }

--- a/src/views/ledger/Statistic.vue
+++ b/src/views/ledger/Statistic.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { useTransactionStore } from '@/stores/useTransactionStore';
 import { storeToRefs } from 'pinia';
 
@@ -28,11 +28,20 @@ onMounted(() => {
 watch(currentFilter, (newVal) => {
   console.log(`${newVal} 필터 적용`);
 });
+
+const hasDataForChart = computed(() => {
+  return categories.value.length > 0 && transactions.value.length > 0;
+});
 </script>
 
 <template>
   <div class="statistics-page">
     <div v-if="loading" class="loading-overlay">데이터를 분석 중입니다...</div>
+
+    <!-- 데이터가 없을 때 표시할 화면 -->
+    <div v-else-if="!hasDataForChart" class="empty-state">
+      데이터가 없습니다.
+    </div>
 
     <div v-else class="content-wrapper">
       <section class="summary-container">
@@ -85,10 +94,8 @@ watch(currentFilter, (newVal) => {
       </div>
 
       <section class="bottom-container">
-        <template v-if="categories.length > 0 && transactions.length > 0">
-          <CategoryChart :active-type="currentType" />
-          <TopCategoryList :active-type="currentType" />
-        </template>
+        <CategoryChart :active-type="currentType" />
+        <TopCategoryList :active-type="currentType" />
       </section>
     </div>
   </div>
@@ -99,6 +106,18 @@ watch(currentFilter, (newVal) => {
   padding: 20px;
   background-color: #f8f9fa;
   min-height: 100vh;
+}
+
+.empty-state {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 60vh;
+  font-size: 1.2rem;
+  color: #888;
+  background: white;
+  border-radius: 15px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.03);
 }
 
 .summary-container {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close: #75 

## ✨ 작업 내용


- 성능 및 구조 리팩토링
    - axiosClient.js: 불필요한 변수 할당 제거 및 반환 로직 간소화
    - useTransactionStore.js: Promise.all을 사용해 거래 내역과 카테고리 데이터 병렬 로드 적용
    - useCategoryStats.js: 카테고리 차트 데이터 가공 로직을 함수형(reduce) 훅으로 분리

- 빈 화면(Empty State) 처리
    - Statistic.vue: 데이터가 없을 경우 표시되는 "데이터가 없습니다." UI 요소 추가

## 💖 리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 통계 페이지에서 도넛 차트가 잘 나오는 지 확인 부탁드립니다~