### PR TITLE
feat: 모바일 하단 네비게이션에 빠른 추가 플로팅 메뉴 도입

### DIFF
--- a/src/components/ledger-layout/LedgerLayoutBottomNav.vue
+++ b/src/components/ledger-layout/LedgerLayoutBottomNav.vue
@@ -1,15 +1,43 @@
 <script setup>
-import { useLedgerLayoutStore } from "@/stores/ledger";
-import { useAddTransactionStore } from "@/stores/transactions/useAddTransactionStore";
-import { useRoute } from "vue-router";
+import { ref } from 'vue';
+import { useLedgerLayoutStore } from '@/stores/ledger';
+import { useAddTransactionStore } from '@/stores/transactions/useAddTransactionStore';
+import { useRoute } from 'vue-router';
 
 const layoutStore = useLedgerLayoutStore();
 const addTransactionStore = useAddTransactionStore();
 const route = useRoute();
+
+const emit = defineEmits(['open-quick-add']);
+
+const isMenuOpen = ref(false);
+
+const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value;
+};
+
+const closeMenu = () => {
+  isMenuOpen.value = false;
+};
+
+const handleDirectAdd = () => {
+  addTransactionStore.openModal();
+  closeMenu();
+};
+
+const handleQuickAdd = () => {
+  emit('open-quick-add');
+  closeMenu();
+};
 </script>
 
 <template>
   <nav class="bottom-nav">
+    <!-- 오버레이 -->
+    <transition name="fade">
+      <div v-if="isMenuOpen" class="fab-overlay" @click="closeMenu"></div>
+    </transition>
+
     <router-link
       v-for="navItem in layoutStore.pages.slice(0, 2)"
       :key="navItem.to.path"
@@ -21,9 +49,33 @@ const route = useRoute();
       <span>{{ navItem.title }}</span>
     </router-link>
 
-    <button class="center-fab" @click="addTransactionStore.openModal">
-      <i class="fa-solid fa-plus"></i>
-    </button>
+    <div class="fab-wrapper">
+      <!-- 추가 플로팅 메뉴 -->
+      <transition name="fade-slide">
+        <div v-if="isMenuOpen" class="fab-menu">
+          <button class="fab-item" @click="handleQuickAdd">
+            <span>빠른 추가</span>
+            <div class="icon-circle quick">
+              <i class="fa-solid fa-bolt"></i>
+            </div>
+          </button>
+          <button class="fab-item" @click="handleDirectAdd">
+            <span>직접 추가</span>
+            <div class="icon-circle direct">
+              <i class="fa-solid fa-pen"></i>
+            </div>
+          </button>
+        </div>
+      </transition>
+
+      <button
+        class="center-fab"
+        :class="{ 'is-active': isMenuOpen }"
+        @click="toggleMenu"
+      >
+        <i class="fa-solid fa-plus" :class="{ 'rotate-icon': isMenuOpen }"></i>
+      </button>
+    </div>
 
     <router-link
       v-for="navItem in layoutStore.pages.slice(2)"
@@ -83,27 +135,140 @@ const route = useRoute();
   color: #00c78b;
 }
 
+.fab-wrapper,
+.fab-overlay {
+  display: none;
+}
 .center-fab {
   display: none;
 }
 
 @media (max-width: 768px) {
+  .fab-overlay {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.6);
+    z-index: 10;
+  }
+
+  .fab-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    flex: 0 0 auto;
+    width: 60px;
+    z-index: 20;
+  }
+
   .center-fab {
     display: flex;
     justify-content: center;
     align-items: center;
-    flex: 0 0 auto;
     width: 60px;
     height: 60px;
     border-radius: 50%;
     background-color: #00bc7c;
-    /* border: 3px solid #0d1520; */
     box-shadow: 0 -4px 12px rgba(0, 188, 124, 0.4);
     color: white;
     font-size: 20px;
     cursor: pointer;
     transform: translateY(-30px);
-    transition: background-color 0.3s ease;
+    transition:
+      transform 0.3s ease,
+      background-color 0.3s ease;
+  }
+
+  .center-fab.is-active {
+    background-color: #ff5252;
+    box-shadow: 0 -4px 12px rgba(255, 82, 82, 0.4);
+  }
+  .center-fab i {
+    transition: transform 0.3s ease;
+  }
+  .center-fab i.rotate-icon {
+    transform: rotate(45deg);
+  }
+
+  .fab-menu {
+    position: absolute;
+    bottom: 100px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-end;
+    right: 6px;
+  }
+
+  .fab-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .fab-item span {
+    background: white;
+    padding: 6px 14px;
+    border-radius: 20px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #333;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+    white-space: nowrap;
+  }
+
+  .icon-circle {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 18px;
+    color: white;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    transition: transform 0.2s;
+    flex-shrink: 0;
+  }
+  .icon-circle:active {
+    transform: scale(0.95);
+  }
+  .icon-circle.quick {
+    background-color: #ff9f43;
+  }
+  .icon-circle.direct {
+    background-color: #00bc7c;
+  }
+
+  /* 애니메이션 */
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity 0.3s ease;
+  }
+  .fade-enter-from,
+  .fade-leave-to {
+    opacity: 0;
+  }
+
+  .fade-slide-enter-active,
+  .fade-slide-leave-active {
+    transition:
+      opacity 0.3s ease,
+      transform 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  .fade-slide-enter-from,
+  .fade-slide-leave-to {
+    opacity: 0;
+    transform: translateY(20px);
   }
 }
 </style>

--- a/src/components/transaction/TransactionQuickAddModal.vue
+++ b/src/components/transaction/TransactionQuickAddModal.vue
@@ -282,6 +282,7 @@ const proceedAdd = async () => {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0; /* 텍스트가 길어질 때 컨테이너 밖으로 넘어가지 않게 제한 */
 }
 .item-category {
   font-size: 0.85rem;
@@ -291,6 +292,9 @@ const proceedAdd = async () => {
   font-size: 1.05rem;
   color: #333;
   font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .item-amount {
   font-weight: 700;
@@ -422,6 +426,60 @@ const proceedAdd = async () => {
   }
   to {
     opacity: 1;
+  }
+}
+
+/* 반응형 모바일 크기 조정 */
+@media (max-width: 768px) {
+  .modal-header {
+    padding: 16px 20px;
+  }
+  .modal-header h3 {
+    font-size: 1.1rem;
+  }
+  .modal-body {
+    padding: 16px 20px;
+  }
+  .recent-item {
+    padding: 12px 8px;
+    margin: 0 -8px;
+    gap: 12px;
+  }
+  .item-icon {
+    width: 36px;
+    height: 36px;
+    font-size: 1rem;
+  }
+  .item-desc {
+    font-size: 0.95rem;
+  }
+  .item-category {
+    font-size: 0.8rem;
+  }
+  .item-amount {
+    font-size: 0.95rem;
+  }
+  .confirm-icon {
+    font-size: 2.5rem;
+  }
+  .confirm-view h4 {
+    font-size: 1.05rem;
+    margin-bottom: 16px;
+  }
+  .confirm-card {
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .cc-detail {
+    font-size: 1.05rem;
+  }
+  .cc-amount {
+    font-size: 1.15rem;
+  }
+  .btn-cancel,
+  .btn-submit {
+    padding: 12px 0;
+    font-size: 0.9rem;
   }
 }
 </style>

--- a/src/layouts/LedgerLayout.vue
+++ b/src/layouts/LedgerLayout.vue
@@ -67,7 +67,7 @@ const handleQuickAdd = () => {
     </div>
   </div>
 
-  <LedgerLayoutBottomNav />
+  <LedgerLayoutBottomNav @open-quick-add="handleQuickAdd" />
   <TransactionAddModal />
 
   <TransactionQuickAddModal


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close: #98 

## ✨ 작업 내용

- [x] 기능 추가
- [ ] 버그 수정

- 모바일 환경에서 중앙 추가 버튼 클릭 시 '빠른 추가'와 '직접 추가'를 선택할 수 있는 플로팅 메뉴(FAB) 구현
- 플로팅 메뉴 아이템의 텍스트 줄바꿈 방지 및 아이콘 원형 유지(flex-shrink: 0) 적용
- LedgerLayout과 이벤트(@open-quick-add)를 연동하여 모바일에서도 빠른 추가 모달이 열리도록 수정
- 모바일 기기(max-width: 768px)에서 모달 여백과 폰트 사이즈를 축소하여 더 컴팩트하고 쾌적한 화면 제공
- 거래 내역의 상세 내용(detail)이 길어질 경우 레이아웃이 깨지지 않도록 CSS 말줄임표(...) 적용

## 💖 리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 기타 당부의 말씀 등 자유롭게 작성해주세요.
