### PR TITLE
refactor: Transaction 서비스 인증 의존성 분리

### DIFF
--- a/src/api/authContext.js
+++ b/src/api/authContext.js
@@ -1,0 +1,6 @@
+import { useAuthStore } from '@/stores/auth/useAuthStore';
+
+export const authContext = {
+  isLoggedIn: () => useAuthStore().isLoggedIn,
+  getUserId: () => useAuthStore().user?.id ?? null,
+};

--- a/src/api/services/transactionService.js
+++ b/src/api/services/transactionService.js
@@ -1,0 +1,24 @@
+import axiosClient from '@/api/axiosClient';
+import { authContext } from '@/api/authContext';
+
+export const transactionService = {
+  async fetchAll() {
+    if (!authContext.isLoggedIn()) return [];
+    return axiosClient.transactionApi.getTransactionsByUserId(authContext.getUserId());
+  },
+
+  async create(payload) {
+    return axiosClient.transactionApi.createTransaction({
+      ...payload,
+      user_id: authContext.getUserId(),
+    });
+  },
+
+  async update(id, payload) {
+    return axiosClient.transactionApi.updateTransaction(id, payload);
+  },
+
+  async remove(id) {
+    return axiosClient.transactionApi.deleteTransaction(id);
+  },
+};

--- a/src/stores/transactions/useAddTransactionStore.js
+++ b/src/stores/transactions/useAddTransactionStore.js
@@ -1,7 +1,6 @@
 import { defineStore } from "pinia";
 import { ref, reactive } from "vue";
 import { useTransactionStore } from "./useTransactionStore";
-import { useAuthStore } from "../auth/useAuthStore";
 
 export const useAddTransactionStore = defineStore("addTransaction", () => {
   const isOpen = ref(false);
@@ -56,16 +55,12 @@ export const useAddTransactionStore = defineStore("addTransaction", () => {
 
   // json-server로 데이터 POST 요청
   const submitTransaction = async () => {
-    // 1. Transaction 데이터 관리를 담당하는 스토어 호출
     const transactionStore = useTransactionStore();
-    const authStore = useAuthStore();
-    const userId = authStore.user.id;
 
     try {
       const payload = {
         ...formData,
         amount: Number(formData.amount),
-        user_id: userId,
         transacted_at: new Date(formData.transacted_at).toISOString(),
         created_at: new Date(),
       };

--- a/src/stores/transactions/useTransactionStore.js
+++ b/src/stores/transactions/useTransactionStore.js
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
-import axiosClient from '@/api/axiosClient';
-import { useAuthStore } from '@/stores/auth/useAuthStore';
+import { transactionService } from '@/api/services/transactionService';
 import { Categories } from '@/constant/categories';
 
 export const useTransactionStore = defineStore('transaction', () => {
@@ -80,18 +79,7 @@ export const useTransactionStore = defineStore('transaction', () => {
   async function fetchData() {
     loading.value = true;
     try {
-      const authStore = useAuthStore();
-      if (!authStore.isLoggedIn) {
-        transactions.value = [];
-        categories.value = []; // 로그아웃 시 카테고리도 초기화
-        return;
-      }
-      const userId = authStore.user.id;
-
-      // Promise.all을 사용하여 트랜잭션과 카테고리 데이터를 병렬로 가져옴
-      const transactionsData =
-        await axiosClient.transactionApi.getTransactionsByUserId(userId);
-      transactions.value = transactionsData;
+      transactions.value = await transactionService.fetchAll();
       categories.value = Object.values(Categories);
     } catch (error) {
       console.error('Data Fetch Error:', error);
@@ -107,7 +95,7 @@ export const useTransactionStore = defineStore('transaction', () => {
       transactions.value.splice(index, 1);
 
       try {
-        await axiosClient.transactionApi.deleteTransaction(id);
+        await transactionService.remove(id);
       } catch (error) {
         transactions.value.splice(index, 0, backup);
         alert('삭제에 실패했습니다.');
@@ -117,8 +105,7 @@ export const useTransactionStore = defineStore('transaction', () => {
 
   async function addTransaction(payload) {
     try {
-      const newTransaction =
-        await axiosClient.transactionApi.createTransaction(payload);
+      const newTransaction = await transactionService.create(payload);
 
       if (newTransaction) {
         transactions.value.push(newTransaction);
@@ -132,29 +119,24 @@ export const useTransactionStore = defineStore('transaction', () => {
       return false;
     }
   }
+
   async function updateTransaction(id, payload) {
     try {
-      // 1. 서버에 수정 요청 (axiosClient를 통해 PUT/PATCH 호출)
-      const updatedData = await axiosClient.transactionApi.updateTransaction(
-        id,
-        payload,
-      );
+      const updatedData = await transactionService.update(id, payload);
 
       if (updatedData) {
-        // 2. 내 로컬 데이터(배열)에서 해당 항목을 찾아 업데이트
         const index = transactions.value.findIndex((t) => t.id === id);
         if (index !== -1) {
           transactions.value[index] = updatedData;
         }
       } else {
-        // 만약 응답값이 명확하지 않다면 전체 데이터를 다시 불러오기
         await fetchData();
       }
-      return true; // 성공 시 true 반환
+      return true;
     } catch (error) {
       console.error('거래 수정 실패:', error);
       alert('거래 내역을 수정하는데 실패했습니다.');
-      return false; // 실패 시 false 반환
+      return false;
     }
   }
 

--- a/src/stores/transactions/useTransactionStore.js
+++ b/src/stores/transactions/useTransactionStore.js
@@ -108,8 +108,7 @@ export const useTransactionStore = defineStore("transaction", () => {
       const newTransaction = await transactionService.create(payload);
 
       if (newTransaction) {
-        transactions.value.push(newTransaction);
-        transactions.value.sort(
+        transactions.value = [...transactions.value, newTransaction].sort(
           (a, b) => new Date(b.transacted_at) - new Date(a.transacted_at),
         );
       } else {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close: #100 

## ✨ 작업 내용

- useTransactionStore에서 axiosClient와 useAuthStore를 직접 참조하던 의존성을 제거하고, transactionService
   서비스 레이어를 통해 API 호출을 위임
- 인증 컨텍스트(authContext)를 별도 모듈로 분리하여 서비스 레이어에서 사용자 정보에 접근
- useAddTransactionStore에서도 useAuthStore 직접 참조를 제거하고 transactionService에 위임
- 트랜잭션 추가 시 push + sort 이중 반응성 트리거를 단일 배열 할당으로 수정하여 불필요한 리렌더링 제거

## 💖 리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 기타 당부의 말씀 등 자유롭게 작성해주세요.
