### PR TITLE
fix: getCategoryById가 항상 미분류를 반환하는 버그 수정

### DIFF
--- a/src/composables/useCategoryStats.js
+++ b/src/composables/useCategoryStats.js
@@ -1,8 +1,8 @@
-import { computed, toValue } from 'vue';
-import { useTransactionStore } from '@/stores/transactions/useTransactionStore';
-import { useCategoryStore } from '@/stores/categories/useCategoryStore';
-import { storeToRefs } from 'pinia';
-import { calculatePercent } from '@/utils/formatter';
+import { computed, toValue } from "vue";
+import { useTransactionStore } from "@/stores/transactions/useTransactionStore";
+import { useCategoryStore } from "@/stores/categories/useCategoryStore";
+import { storeToRefs } from "pinia";
+import { calculatePercent } from "@/utils/formatter";
 
 export function useCategoryStats(activeTypeRef) {
   const transactionStore = useTransactionStore();
@@ -10,7 +10,10 @@ export function useCategoryStats(activeTypeRef) {
   const { thisMonthTransactions } = storeToRefs(transactionStore);
 
   const aggregatedStats = computed(() => {
-    if (!thisMonthTransactions.value?.length || !categoryStore.categories.length) {
+    if (
+      !thisMonthTransactions.value?.length ||
+      !categoryStore.categories.length
+    ) {
       return [];
     }
 
@@ -29,14 +32,14 @@ export function useCategoryStats(activeTypeRef) {
 
     return Object.entries(categoryMap)
       .map(([catId, stats]) => {
-        const category = categoryStore.getCategoryById(Number(catId));
+        const category = categoryStore.getCategoryById(catId);
 
         return {
-          name: category?.name ?? '기타',
+          name: category?.name ?? "기타",
           amount: stats.amount,
           count: stats.count,
-          color: category?.color ?? '#ccc',
-          icon: category?.icon ?? 'fa-solid fa-tag',
+          color: category?.color ?? "#ccc",
+          icon: category?.icon ?? "fa-solid fa-tag",
         };
       })
       .sort((a, b) => b.amount - a.amount);

--- a/src/stores/categories/useCategoryStore.js
+++ b/src/stores/categories/useCategoryStore.js
@@ -14,10 +14,10 @@ export const useCategoryStore = defineStore("category", () => {
     }
   }
 
-  const DEFAULT_CATEGORY = { name: '미분류', ...DEFAULT_CATEGORY_UI };
+  const DEFAULT_CATEGORY = { name: "미분류", ...DEFAULT_CATEGORY_UI };
 
   function getCategoryById(id) {
-    return categories.value.find((c) => c.id === id) ?? DEFAULT_CATEGORY;
+    return categories.value.find((c) => String(c.id) === String(id)) ?? DEFAULT_CATEGORY;
   }
 
   return { categories, fetchCategories, getCategoryById };

--- a/src/views/ledger/Statistic.vue
+++ b/src/views/ledger/Statistic.vue
@@ -9,7 +9,7 @@ import SummaryCard from '@/components/statistic/SummaryCard.vue';
 import TopCategoryList from '@/components/statistic/TopCategoryList.vue';
 
 const store = useTransactionStore();
-const { transactions, categories, summaryStats, loading } = storeToRefs(store);
+const { transactions, summaryStats, loading } = storeToRefs(store);
 
 const filters = [
   { label: '주간별', value: 'weekly' },

--- a/src/views/ledger/Transactions.vue
+++ b/src/views/ledger/Transactions.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useTransactionStore } from '@/stores/transactions/useTransactionStore';
+import { useCategoryStore } from '@/stores/categories/useCategoryStore';
 import TransactionList from '@/components/transaction/TransactionList.vue';
 import TransactionAddModal from '@/components/transaction/TransactionAddModal.vue';
 import { useAuthStore } from '@/stores/auth/useAuthStore';
@@ -11,7 +12,8 @@ const transactionStore = useTransactionStore();
 const authStore = useAuthStore();
 
 // 데이터(ref)는 storeToRefs로 감싸서 꺼내야 화면이 실시간으로 바뀜
-const { transactions, categories, loading } = storeToRefs(transactionStore);
+const { transactions, loading } = storeToRefs(transactionStore);
+const { categories } = storeToRefs(useCategoryStore());
 
 // 함수(액션)는 그냥 바로 꺼냅니다.
 const { fetchData, deleteTransaction, updateTransaction } = transactionStore;
@@ -263,7 +265,6 @@ const formatCurrency = (val) => new Intl.NumberFormat('ko-KR').format(val);
     <template v-else>
       <TransactionList
         :transactions="pagedTransactions"
-        :categories="categories"
         @delete="deleteTransaction"
         @edit="updateTransaction"
       />


### PR DESCRIPTION
## 관련 이슈
Closes #104

## 변경 사항

`getCategoryById`에서 id 타입 불일치로 인해 항상 `DEFAULT_CATEGORY`(미분류)를 반환하던 버그 수정.

## 원인

json-server가 `id`를 **string** 타입으로 반환하는데, strict equality(`===`)로 비교해서 `find`가 항상 `undefined`를 반환.

## 해결

```js
// before
categories.value.find((c) => c.id === id)

// after
categories.value.find((c) => String(c.id) === String(id))
```

양쪽을 `String()`으로 명시 변환하여 타입 무관하게 비교.