### PR TITLE
feat: Not Found 페이지 구현 및 랜딩 레이아웃 분리

### DIFF
--- a/src/layouts/LandingLayout.vue
+++ b/src/layouts/LandingLayout.vue
@@ -1,0 +1,184 @@
+<script setup>
+import { nextTick, provide, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import AuthModal from "@/components/auth/AuthModal.vue";
+import { useAuthStore } from "@/stores/auth/useAuthStore";
+
+const route = useRoute();
+const router = useRouter();
+const authStore = useAuthStore();
+
+const showAuthModal = ref(false);
+const openAuthModal = () => {
+  showAuthModal.value = true;
+};
+
+const navItems = [
+  { id: "intro", label: "소개" },
+  { id: "features", label: "핵심 기능" },
+  { id: "preview", label: "실제 화면" },
+];
+
+const scrollToSection = (sectionId) => {
+  if (route.name !== "Home") {
+    router.push({ name: "Home", hash: `#${sectionId}` });
+    return;
+  }
+
+  const element = document.getElementById(sectionId);
+  if (element) {
+    element.scrollIntoView({ behavior: "smooth" });
+  }
+};
+
+const handlePrimaryAction = () => {
+  if (authStore.isLoggedIn) {
+    router.push("/ledger/dashboard");
+    return;
+  }
+
+  showAuthModal.value = true;
+};
+
+const scrollToHash = async (hash) => {
+  if (!hash) return;
+
+  await nextTick();
+  const element = document.querySelector(hash);
+  if (element) {
+    element.scrollIntoView({ behavior: "smooth" });
+  }
+};
+
+provide("openAuthModal", openAuthModal);
+
+watch(
+  () => route.hash,
+  (hash) => {
+    scrollToHash(hash);
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <div class="landing-layout">
+    <header class="navbar">
+      <button class="logo" @click="router.push('/')">
+        <i class="fa-solid fa-wallet"></i>머니로그
+      </button>
+
+      <nav v-if="route.name === 'Home'" class="nav-menu">
+        <button
+          v-for="item in navItems"
+          :key="item.id"
+          @click="scrollToSection(item.id)"
+        >
+          {{ item.label }}
+        </button>
+      </nav>
+
+      <button class="login-btn" @click="handlePrimaryAction">
+        {{ authStore.isLoggedIn ? "대시보드" : "로그인" }}
+      </button>
+    </header>
+
+    <router-view />
+
+    <AuthModal v-if="showAuthModal" @close="showAuthModal = false" />
+  </div>
+</template>
+
+<style scoped>
+.landing-layout {
+  min-height: 100vh;
+  background-color: #f8f9fa;
+  display: flex;
+  flex-direction: column;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 50px;
+  background: white;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  gap: 24px;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #20bf6b;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.nav-menu {
+  display: flex;
+  gap: 30px;
+}
+
+.nav-menu button {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #2f3542;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.nav-menu button:hover {
+  color: #20bf6b;
+}
+
+.login-btn {
+  padding: 10px 24px;
+  border: none;
+  border-radius: 8px;
+  background-color: #2f3542;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  flex-shrink: 0;
+}
+
+.login-btn:hover {
+  background-color: #57606f;
+}
+
+@media (max-width: 768px) {
+  .navbar {
+    padding: 15px 20px;
+    gap: 16px;
+  }
+
+  .nav-menu {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .navbar {
+    padding: 14px 16px;
+  }
+
+  .logo {
+    font-size: 1.25rem;
+  }
+
+  .login-btn {
+    padding: 9px 14px;
+    font-size: 0.95rem;
+  }
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,7 +1,6 @@
 import "@/assets/main.css";
 
 import { createRouter, createWebHistory } from "vue-router";
-import Home from "@/views/Home.vue";
 import { useAuthStore } from "@/stores/auth/useAuthStore";
 
 const router = createRouter({
@@ -9,8 +8,19 @@ const router = createRouter({
   routes: [
     {
       path: "/",
-      name: "Home",
-      component: Home,
+      component: () => import("@/layouts/LandingLayout.vue"),
+      children: [
+        {
+          path: "",
+          name: "Home",
+          component: () => import("@/views/Home.vue"),
+        },
+        {
+          path: ":pathMatch(.*)*",
+          name: "NotFound",
+          component: () => import("@/views/NotFound.vue"),
+        },
+      ],
     },
     {
       path: "/ledger",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,25 +1,33 @@
 <script setup>
-import { ref, onMounted, onUnmounted } from "vue";
+import { inject, ref, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
-import AuthModal from "@/components/auth/AuthModal.vue";
 import { useAuthStore } from "@/stores/auth/useAuthStore";
 
 const router = useRouter();
 const authStore = useAuthStore();
 const { isLoggedIn } = authStore;
-
-const scrollToSection = (sectionId) => {
-  const element = document.getElementById(sectionId);
-  if (element) {
-    element.scrollIntoView({ behavior: "smooth" });
-  }
-};
+const openAuthModal = inject("openAuthModal", null);
 
 const showScrollTop = ref(false);
-const showAuthModal = ref(false);
 
 const handleScroll = () => {
   showScrollTop.value = window.scrollY > 300;
+};
+
+const handlePrimaryAction = () => {
+  if (isLoggedIn) {
+    router.push("/ledger/dashboard");
+    return;
+  }
+
+  openAuthModal?.();
+};
+
+const scrollToIntro = () => {
+  const element = document.getElementById("intro");
+  if (element) {
+    element.scrollIntoView({ behavior: "smooth" });
+  }
 };
 
 onMounted(() => {
@@ -32,33 +40,6 @@ onUnmounted(() => {
 
 <template>
   <div class="landing-page">
-    <!-- 네비게이션 바 -->
-    <header class="navbar">
-      <div class="logo"><i class="fa-solid fa-wallet"></i>머니로그</div>
-
-      <nav class="nav-menu">
-        <button @click="scrollToSection('intro')">소개</button>
-        <button @click="scrollToSection('features')">핵심 기능</button>
-        <button @click="scrollToSection('preview')">실제 화면</button>
-      </nav>
-
-      <button
-        v-if="!isLoggedIn"
-        class="login-btn"
-        @click="showAuthModal = true"
-      >
-        로그인
-      </button>
-      <button
-        v-else
-        class="login-btn"
-        @click="router.push('/ledger/dashboard')"
-      >
-        대시보드
-      </button>
-    </header>
-
-    <!-- 메인 히어로 섹션 -->
     <main id="intro" class="hero-section">
       <div class="hero-content">
         <span class="badge">스마트한 가계부</span>
@@ -70,7 +51,7 @@ onUnmounted(() => {
         <button
           v-if="!isLoggedIn"
           class="cta-btn"
-          @click="showAuthModal = true"
+          @click="handlePrimaryAction"
         >
           지금 바로 시작하기
         </button>
@@ -88,26 +69,22 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- 스크롤 유도 애니메이션 -->
       <div class="scroll-indicator">
         <i class="fa-solid fa-chevron-down"></i>
       </div>
     </main>
 
-    <!-- 기능 소개 섹션 -->
     <section id="features" class="features-section">
       <div class="features-header">
         <h2>- 핵심 기능 -</h2>
         <p>복잡한 자산 관리를 쉽고 간편하게 만들어주는 기능을 만나보세요.</p>
       </div>
       <div class="features-grid">
-        <!-- Feature 1 -->
         <div class="feature-card">
           <div class="feature-icon"><i class="fa-solid fa-chart-line"></i></div>
           <h3>한눈에 보는 대시보드</h3>
           <p>수입과 지출 흐름을 달력과 차트로 직관적으로 파악할 수 있습니다.</p>
         </div>
-        <!-- Feature 2 -->
         <div class="feature-card">
           <div class="feature-icon"><i class="fa-solid fa-chart-pie"></i></div>
           <h3>상세한 통계 분석</h3>
@@ -115,7 +92,6 @@ onUnmounted(() => {
             카테고리별, 기간별 통계를 통해 나의 소비 패턴을 정확하게 분석합니다.
           </p>
         </div>
-        <!-- Feature 3 -->
         <div class="feature-card">
           <div class="feature-icon"><i class="fa-solid fa-list-check"></i></div>
           <h3>간편한 내역 관리</h3>
@@ -124,7 +100,6 @@ onUnmounted(() => {
       </div>
     </section>
 
-    <!-- 실제 화면 프리뷰 섹션 -->
     <section id="preview" class="preview-section">
       <div class="preview-header">
         <h2>- 실제 화면 -</h2>
@@ -132,7 +107,6 @@ onUnmounted(() => {
       </div>
       <div class="preview-content">
         <div class="mockup-window">
-          <!-- 추후 실제 대시보드 캡처 이미지로 교체할 영역 -->
           <div class="mockup-placeholder">
             <i class="fa-solid fa-laptop-code"></i>
             <p>대시보드 화면 캡처가 들어갈 자리입니다.</p>
@@ -141,73 +115,20 @@ onUnmounted(() => {
       </div>
     </section>
 
-    <!-- 최상단으로 이동 버튼 -->
     <button
       v-if="showScrollTop"
       class="scroll-top-btn"
-      @click="scrollToSection('intro')"
+      @click="scrollToIntro"
     >
       <i class="fa-solid fa-arrow-up"></i>
     </button>
-
-    <!-- 로그인/회원가입 모달 -->
-    <AuthModal v-if="showAuthModal" @close="showAuthModal = false" />
   </div>
 </template>
 
 <style scoped>
 .landing-page {
-  min-height: 100vh;
-  background-color: #f8f9fa;
   display: flex;
   flex-direction: column;
-}
-
-/* 네비게이션 바 */
-.navbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 50px;
-  background: white;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-}
-.logo {
-  font-size: 1.5rem;
-  font-weight: 800;
-  color: #20bf6b;
-}
-
-/* 중앙 네비게이션 메뉴 */
-.nav-menu {
-  display: flex;
-  gap: 30px;
-}
-.nav-menu button {
-  background: none;
-  border: none;
-  font-size: 1rem;
-  font-weight: 600;
-  color: #2f3542;
-  cursor: pointer;
-  transition: color 0.2s;
-}
-.nav-menu button:hover {
-  color: #20bf6b;
-}
-
-.login-btn {
-  padding: 10px 24px;
-  border: none;
-  border-radius: 8px;
-  background-color: #2f3542;
-  color: white;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-.login-btn:hover {
-  background-color: #57606f;
 }
 
 /* 히어로 섹션 */
@@ -479,9 +400,6 @@ onUnmounted(() => {
 }
 
 @media (max-width: 768px) {
-  .navbar {
-    padding: 15px 20px;
-  }
   .title {
     font-size: 2.2rem;
   }
@@ -492,9 +410,6 @@ onUnmounted(() => {
     width: 240px;
     height: 240px;
     font-size: 5rem;
-  }
-  .nav-menu {
-    display: none; /* 모바일 환경에서는 텍스트 메뉴를 임시로 숨김 */
   }
   .features-grid {
     grid-template-columns: 1fr;

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,236 @@
+<script setup>
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth/useAuthStore";
+
+const router = useRouter();
+const authStore = useAuthStore();
+
+const goHome = () => {
+  router.push("/");
+};
+
+const goPrimary = () => {
+  router.push(authStore.isLoggedIn ? "/ledger/dashboard" : "/");
+};
+</script>
+
+<template>
+  <main class="not-found-page">
+    <div class="hero-section">
+      <div class="hero-content">
+        <span class="badge">404 ERROR</span>
+        <h1 class="title">찾으시는 페이지가<br />존재하지 않습니다</h1>
+        <p class="subtitle">
+          주소가 잘못 입력되었거나 페이지가 이동되었을 수 있습니다.<br />
+          머니로그 홈 또는 대시보드에서 다시 시작해보세요.
+        </p>
+
+        <div class="button-group">
+          <button class="cta-btn" @click="goHome">홈으로 이동</button>
+          <button
+            v-if="authStore.isLoggedIn"
+            class="secondary-btn"
+            @click="router.push('/ledger/dashboard')"
+          >
+            대시보드로 이동
+          </button>
+          <button
+            v-else
+            class="secondary-btn"
+            @click="goPrimary"
+          >
+            로그인하기
+          </button>
+        </div>
+      </div>
+
+      <div class="hero-image">
+        <div class="placeholder-img">
+          <div class="error-code">404</div>
+          <i class="fa-solid fa-triangle-exclamation"></i>
+        </div>
+      </div>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+.not-found-page {
+  flex: 1;
+  display: flex;
+}
+
+.hero-section {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px 20px;
+  gap: 60px;
+}
+
+.hero-content {
+  flex: 1;
+}
+
+.badge {
+  display: inline-block;
+  padding: 6px 12px;
+  background: #e6f7ef;
+  color: #28c76f;
+  border-radius: 20px;
+  font-weight: bold;
+  font-size: 0.9rem;
+  margin-bottom: 20px;
+}
+
+.title {
+  font-size: 3rem;
+  line-height: 1.3;
+  color: #2f3542;
+  margin: 0 0 20px 0;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: #747d8c;
+  margin-bottom: 40px;
+}
+
+.button-group {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.cta-btn,
+.secondary-btn {
+  padding: 16px 32px;
+  border: none;
+  border-radius: 12px;
+  font-size: 1.05rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition:
+    transform 0.2s,
+    background-color 0.2s,
+    border-color 0.2s;
+}
+
+.cta-btn {
+  background-color: #20bf6b;
+  color: white;
+}
+
+.cta-btn:hover {
+  background-color: #1da35b;
+  transform: translateY(-2px);
+}
+
+.secondary-btn {
+  background: white;
+  color: #2f3542;
+  border: 1px solid #dfe4ea;
+}
+
+.secondary-btn:hover {
+  border-color: #20bf6b;
+  transform: translateY(-2px);
+}
+
+.hero-image {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.placeholder-img {
+  position: relative;
+  width: 400px;
+  height: 400px;
+  background: linear-gradient(135deg, #e0f2fe 0%, #e6f7ef 100%);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08);
+  color: #28c76f;
+}
+
+.placeholder-img i {
+  font-size: 6.5rem;
+}
+
+.error-code {
+  position: absolute;
+  top: 78px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 3.4rem;
+  font-weight: 800;
+  color: #2f3542;
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 992px) {
+  .hero-section {
+    flex-direction: column;
+    text-align: center;
+    justify-content: center;
+  }
+
+  .button-group {
+    justify-content: center;
+  }
+
+  .placeholder-img {
+    width: 300px;
+    height: 300px;
+  }
+
+  .placeholder-img i {
+    font-size: 5rem;
+  }
+
+  .error-code {
+    top: 56px;
+    font-size: 2.8rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .title {
+    font-size: 2.2rem;
+  }
+
+  .subtitle {
+    font-size: 1rem;
+  }
+
+  .button-group {
+    flex-direction: column;
+  }
+
+  .cta-btn,
+  .secondary-btn {
+    width: 100%;
+  }
+
+  .placeholder-img {
+    width: 240px;
+    height: 240px;
+  }
+
+  .placeholder-img i {
+    font-size: 4rem;
+  }
+
+  .error-code {
+    top: 44px;
+    font-size: 2.2rem;
+  }
+}
+</style>


### PR DESCRIPTION
## 요약
- 랜딩 공용 `LandingLayout`을 추가했습니다.
- `Home`와 `NotFound`가 공용 헤더와 인증 모달을 공유하도록 구조를 정리했습니다.
- 존재하지 않는 경로를 404 페이지로 연결했습니다.

## 변경 이유
- 홈과 404 페이지가 헤더와 반응형 스타일을 각각 관리하고 있어 UI 동작이 쉽게 어긋나던 문제를 줄이기 위해서입니다.

## 영향
- 랜딩 페이지 계열 화면의 헤더 동작과 모바일 정렬이 일관됩니다.
- 잘못된 경로 접근 시 공용 랜딩 레이아웃 안에서 404 페이지가 표시됩니다.

## 검증
- `npm run build`

Closes #106
