### PR TITLE
feat: 카테고리별 월별 예산 설정 기능 구현 (#108)

### DIFF
--- a/server/db.dev.json
+++ b/server/db.dev.json
@@ -9,21 +9,158 @@
     }
   ],
   "categories": [
-    { "id": 1, "code": "FOOD", "name": "식비", "type": "EXPENSE" },
-    { "id": 2, "code": "CAFE", "name": "카페", "type": "EXPENSE" },
-    { "id": 3, "code": "TRANSPORT", "name": "교통", "type": "EXPENSE" },
-    { "id": 4, "code": "SHOPPING", "name": "쇼핑", "type": "EXPENSE" },
-    { "id": 5, "code": "GROCERIES", "name": "식료품", "type": "EXPENSE" },
-    { "id": 6, "code": "SUBSCRIPTION", "name": "구독", "type": "EXPENSE" },
-    { "id": 7, "code": "HEALTH", "name": "건강", "type": "EXPENSE" },
-    { "id": 8, "code": "EDUCATION", "name": "교육", "type": "EXPENSE" },
-    { "id": 9, "code": "LEISURE", "name": "여가", "type": "EXPENSE" },
-    { "id": 10, "code": "ETC_EXPENSE", "name": "기타", "type": "EXPENSE" },
-    { "id": 11, "code": "SALARY", "name": "급여", "type": "INCOME" },
-    { "id": 12, "code": "SIDE_JOB", "name": "부업", "type": "INCOME" },
-    { "id": 13, "code": "INVESTMENT", "name": "투자", "type": "INCOME" },
-    { "id": 14, "code": "ALLOWANCE", "name": "용돈", "type": "INCOME" },
-    { "id": 15, "code": "ETC_INCOME", "name": "기타", "type": "INCOME" }
+    {
+      "id": 1,
+      "code": "FOOD",
+      "name": "식비",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 2,
+      "code": "CAFE",
+      "name": "카페",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 3,
+      "code": "TRANSPORT",
+      "name": "교통",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 4,
+      "code": "SHOPPING",
+      "name": "쇼핑",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 5,
+      "code": "GROCERIES",
+      "name": "식료품",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 6,
+      "code": "SUBSCRIPTION",
+      "name": "구독",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 7,
+      "code": "HEALTH",
+      "name": "건강",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 8,
+      "code": "EDUCATION",
+      "name": "교육",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 9,
+      "code": "LEISURE",
+      "name": "여가",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 10,
+      "code": "ETC_EXPENSE",
+      "name": "기타",
+      "type": "EXPENSE"
+    },
+    {
+      "id": 11,
+      "code": "SALARY",
+      "name": "급여",
+      "type": "INCOME"
+    },
+    {
+      "id": 12,
+      "code": "SIDE_JOB",
+      "name": "부업",
+      "type": "INCOME"
+    },
+    {
+      "id": 13,
+      "code": "INVESTMENT",
+      "name": "투자",
+      "type": "INCOME"
+    },
+    {
+      "id": 14,
+      "code": "ALLOWANCE",
+      "name": "용돈",
+      "type": "INCOME"
+    },
+    {
+      "id": 15,
+      "code": "ETC_INCOME",
+      "name": "기타",
+      "type": "INCOME"
+    }
+  ],
+  "budgets": [
+    {
+      "user_id": 1,
+      "category_id": 1,
+      "amount": 1000000,
+      "id": 1
+    },
+    {
+      "user_id": 1,
+      "category_id": 2,
+      "amount": 0,
+      "id": 2
+    },
+    {
+      "user_id": 1,
+      "category_id": 3,
+      "amount": 50000,
+      "id": 3
+    },
+    {
+      "user_id": 1,
+      "category_id": 4,
+      "amount": 0,
+      "id": 4
+    },
+    {
+      "user_id": 1,
+      "category_id": 5,
+      "amount": 0,
+      "id": 5
+    },
+    {
+      "user_id": 1,
+      "category_id": 6,
+      "amount": 0,
+      "id": 6
+    },
+    {
+      "user_id": 1,
+      "category_id": 7,
+      "amount": 0,
+      "id": 7
+    },
+    {
+      "user_id": 1,
+      "category_id": 8,
+      "amount": 0,
+      "id": 8
+    },
+    {
+      "user_id": 1,
+      "category_id": 9,
+      "amount": 0,
+      "id": 9
+    },
+    {
+      "user_id": 1,
+      "category_id": 10,
+      "amount": 0,
+      "id": 10
+    }
   ],
   "transactions": [
     {
@@ -325,6 +462,46 @@
       "method": "CARD",
       "transacted_at": "2026-04-11T19:00:00.000Z",
       "created_at": "2026-04-11T19:00:00.000Z"
+    },
+    {
+      "type": "EXPENSE",
+      "amount": 1500,
+      "category_id": 3,
+      "detail": "버스",
+      "transacted_at": "2026-04-12T15:44:36.534Z",
+      "user_id": 1,
+      "id": 26
+    },
+    {
+      "type": "EXPENSE",
+      "transacted_at": "2026-04-12T00:00:00.000Z",
+      "amount": 50000,
+      "category_id": 8,
+      "detail": "교육",
+      "memo": "",
+      "method": "CARD",
+      "created_at": "2026-04-12T15:45:15.557Z",
+      "user_id": 1,
+      "id": 27
+    },
+    {
+      "type": "EXPENSE",
+      "amount": 15000,
+      "category_id": 7,
+      "detail": "약국",
+      "transacted_at": "2026-04-12T15:45:25.665Z",
+      "user_id": 1,
+      "id": 28
+    },
+    {
+      "type": "EXPENSE",
+      "amount": 1500,
+      "category_id": 3,
+      "detail": "버스",
+      "transacted_at": "2026-04-12T17:29:02.259Z",
+      "user_id": 1,
+      "id": 29
     }
-  ]
+  ],
+  "$schema": "./node_modules/json-server/schema.json"
 }

--- a/server/db.json
+++ b/server/db.json
@@ -1,4 +1,5 @@
 {
+  "budgets": [],
   "categories": [
     { "id": 1,  "code": "FOOD",         "name": "식비",   "type": "EXPENSE" },
     { "id": 2,  "code": "CAFE",         "name": "카페",   "type": "EXPENSE" },

--- a/src/api/axiosClient.js
+++ b/src/api/axiosClient.js
@@ -1,12 +1,12 @@
-import axios from 'axios';
+import axios from "axios";
 import {
   FetchFailedError,
   NetworkOfflineError,
   SaveFailedError,
-} from './networkError';
-import { ErrorCode } from '@/constant/errorCode';
+} from "./networkError";
+import { ErrorCode } from "@/constant/errorCode";
 
-const urlPrefix = '/api';
+const urlPrefix = "/api";
 
 const isRequestSuccessful = (statusCode) => {
   return statusCode >= 200 && statusCode < 300;
@@ -102,7 +102,11 @@ async function getTransaction(transactionId) {
 }
 
 async function getTransactionsByUserId(userId) {
-  const res = await axios.get(`${urlPrefix}/transactions?user_id:eq=${userId}`);
+  const res = await axios.get(`${urlPrefix}/transactions`, {
+    params: { user_id: userId },
+  });
+
+  checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
 
   return res.data;
 }
@@ -140,6 +144,32 @@ async function getCategories() {
   return res.data;
 }
 
+async function getBudgets(userId) {
+  const res = await axios.get(`${urlPrefix}/budgets`, {
+    params: { user_id: userId },
+  });
+
+  checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
+
+  return res.data;
+}
+
+async function createBudget(budget) {
+  const res = await axios.post(`${urlPrefix}/budgets`, budget);
+
+  checkRequestFailed(res.status, ErrorCode.SAVE_FAILED);
+
+  return res.data;
+}
+
+async function updateBudget(id, budget) {
+  const res = await axios.put(`${urlPrefix}/budgets/${id}`, budget);
+
+  checkRequestFailed(res.status, ErrorCode.SAVE_FAILED);
+
+  return res.data;
+}
+
 const memberApi = {
   getMembers,
   getMember,
@@ -162,4 +192,10 @@ const categoryApi = {
   getCategories,
 };
 
-export default { memberApi, transactionApi, categoryApi };
+const budgetApi = {
+  getBudgets,
+  createBudget,
+  updateBudget,
+};
+
+export default { memberApi, transactionApi, categoryApi, budgetApi };

--- a/src/api/services/budgetService.js
+++ b/src/api/services/budgetService.js
@@ -1,0 +1,41 @@
+import axiosClient from "@/api/axiosClient";
+import { authContext } from "@/api/authContext";
+
+export const budgetService = {
+  async fetchAll() {
+    if (!authContext.isLoggedIn()) return [];
+
+    const budgets = await axiosClient.budgetApi.getBudgets(
+      authContext.getUserId(),
+    );
+    return budgets;
+  },
+
+  async save(draftBudgets) {
+    const userId = authContext.getUserId();
+
+    const existingBudgets = await axiosClient.budgetApi.getBudgets(userId);
+    const existingMap = Object.fromEntries(
+      existingBudgets.map((b) => [String(b.category_id), b.id]),
+    );
+
+    await Promise.all(
+      Object.entries(draftBudgets).map(([category_id, amount]) => {
+        const existingId = existingMap[category_id];
+        if (existingId) {
+          return axiosClient.budgetApi.updateBudget(existingId, {
+            user_id: userId,
+            category_id,
+            amount,
+          });
+        } else {
+          return axiosClient.budgetApi.createBudget({
+            user_id: userId,
+            category_id,
+            amount,
+          });
+        }
+      }),
+    );
+  },
+};

--- a/src/components/mypage/BudgetSection.vue
+++ b/src/components/mypage/BudgetSection.vue
@@ -1,27 +1,33 @@
 <script setup>
 import { useCategoryStore } from "@/stores/categories/useCategoryStore";
+import { useBudgetStore } from "@/stores/budgets/useBudgetStore";
+import { useTransactionStore } from "@/stores/transactions/useTransactionStore";
+import { storeToRefs } from "pinia";
 import { formatAmount, formatAmountShort } from "@/utils/formatter";
-import { computed, ref, watch } from "vue";
+import { computed, ref, onMounted } from "vue";
+
+const isEditMode = ref(false);
+const isSaving = ref(false);
 
 const categoryStore = useCategoryStore();
-const isEditMode = ref(false);
-
 const expenseCategories = computed(() =>
   categoryStore.categories.filter((cat) => cat.type === "EXPENSE"),
 );
 
-const budgets = ref({});
+const budgetStore = useBudgetStore();
+const { budgets } = storeToRefs(budgetStore);
 
-watch(expenseCategories, (cats) => {
-  if (cats.length && !Object.keys(budgets.value).length) {
-    budgets.value = Object.fromEntries(cats.map((cat) => [cat.id, 100000]));
-  }
-}, { immediate: true });
+onMounted(() => {
+  budgetStore.fetchBudgets();
+  transactionStore.fetchData();
+});
 
 const draftBudgets = ref({});
 
 const enterEditMode = () => {
-  draftBudgets.value = { ...budgets.value };
+  draftBudgets.value = Object.fromEntries(
+    expenseCategories.value.map((cat) => [cat.id, budgets.value[cat.id] ?? 0]),
+  );
   isEditMode.value = true;
 };
 
@@ -29,10 +35,31 @@ const cancelEdit = () => {
   isEditMode.value = false;
 };
 
-const saveEdit = () => {
-  budgets.value = { ...draftBudgets.value };
-  isEditMode.value = false;
+const saveEdit = async () => {
+  isSaving.value = true;
+  try {
+    await budgetStore.saveBudgets(draftBudgets.value);
+    isEditMode.value = false;
+  } catch {
+    alert("저장에 실패했습니다.");
+  } finally {
+    isSaving.value = false;
+  }
 };
+
+const transactionStore = useTransactionStore();
+const { thisMonthTransactions } = storeToRefs(transactionStore);
+
+const spendingByCategory = computed(() =>
+  thisMonthTransactions.value
+    .filter((t) => t.type === "EXPENSE")
+    .reduce((acc, t) => {
+      acc[String(t.category_id)] = (acc[String(t.category_id)] ?? 0) + t.amount;
+      return acc;
+    }, {}),
+);
+
+const getSpending = (catId) => spendingByCategory.value[String(catId)] ?? 0;
 
 const totalBudget = computed(() => {
   const source = isEditMode.value ? draftBudgets.value : budgets.value;
@@ -40,7 +67,6 @@ const totalBudget = computed(() => {
 });
 
 const formatKRW = (amount) => formatAmount(amount) + "원";
-
 const formatComma = (amount) => Number(amount).toLocaleString("ko-KR");
 
 const onBudgetInput = (event, catId) => {
@@ -51,12 +77,14 @@ const onBudgetInput = (event, catId) => {
 };
 
 const getPercent = (catId) => {
-  if (totalBudget.value === 0) return 0;
-  return (budgets.value[catId] / totalBudget.value) * 100;
+  const budget = budgets.value[String(catId)] ?? 0;
+  if (budget === 0) return 0;
+  return Math.min((getSpending(catId) / budget) * 100, 100);
 };
 
-const formatPercent = (catId) => {
-  return `전체의 ${getPercent(catId).toFixed(1)}%`;
+const isOverBudget = (catId) => {
+  const budget = budgets.value[String(catId)] ?? 0;
+  return budget > 0 && getSpending(catId) > budget;
 };
 
 const hexToRgba = (hex, alpha) => {
@@ -128,24 +156,31 @@ const hexToRgba = (hex, alpha) => {
           <span class="unit">원</span>
         </div>
         <template v-if="!isEditMode">
-          <span class="cat-amount">{{ formatKRW(budgets[cat.id]) }}</span>
+          <span class="spending-amount" :class="{ 'over-budget': isOverBudget(cat.id) }">
+            {{ formatKRW(getSpending(cat.id)) }}
+          </span>
+          <span class="budget-label">예산 {{ formatKRW(budgets[cat.id] ?? 0) }}</span>
           <div class="progress-bar-track">
             <div
               class="progress-bar-fill"
               :style="{
                 width: getPercent(cat.id) + '%',
-                backgroundColor: cat.color,
+                backgroundColor: isOverBudget(cat.id) ? '#ef4444' : cat.color,
               }"
             ></div>
           </div>
-          <span class="cat-percent">{{ formatPercent(cat.id) }}</span>
+          <span class="cat-percent" :class="{ 'over-budget': isOverBudget(cat.id) }">
+            {{ getPercent(cat.id).toFixed(1) }}%
+          </span>
         </template>
       </div>
     </div>
 
     <div v-if="isEditMode" class="edit-actions">
-      <button class="cancel-btn" @click="cancelEdit">취소</button>
-      <button class="save-btn" @click="saveEdit">저장하기</button>
+      <button class="cancel-btn" @click="cancelEdit" :disabled="isSaving">취소</button>
+      <button class="save-btn" @click="saveEdit" :disabled="isSaving">
+        {{ isSaving ? "저장 중..." : "저장하기" }}
+      </button>
     </div>
   </div>
 </template>
@@ -313,10 +348,19 @@ const hexToRgba = (hex, alpha) => {
   color: #1c1c1e;
 }
 
-.cat-amount {
+.spending-amount {
   font-size: 14px;
   font-weight: bold;
   color: #1c1c1e;
+}
+
+.spending-amount.over-budget {
+  color: #ef4444;
+}
+
+.budget-label {
+  font-size: 11px;
+  color: #8a8a8e;
 }
 
 .progress-bar-track {
@@ -336,6 +380,10 @@ const hexToRgba = (hex, alpha) => {
 .cat-percent {
   font-size: 11px;
   color: #8a8a8e;
+}
+
+.cat-percent.over-budget {
+  color: #ef4444;
 }
 
 .budget-input-wrapper {
@@ -392,6 +440,11 @@ const hexToRgba = (hex, alpha) => {
   transition: background-color 0.3s ease;
 }
 
+.edit-actions > button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .cancel-btn {
   background-color: white;
   color: #48484a;
@@ -443,8 +496,6 @@ const hexToRgba = (hex, alpha) => {
     grid-template-columns: 1fr;
   }
 
-  .cat-amount {
-    text-align: right;
-  }
 }
+
 </style>

--- a/src/stores/budgets/useBudgetStore.js
+++ b/src/stores/budgets/useBudgetStore.js
@@ -1,0 +1,50 @@
+import { defineStore } from "pinia";
+import { ref, watch } from "vue";
+import { budgetService } from "@/api/services/budgetService";
+import { useAuthStore } from "@/stores/auth/useAuthStore";
+
+export const useBudgetStore = defineStore("budget", () => {
+  const budgets = ref({}); // { [category_id]: amount }
+
+  function getBudgetAmount(categoryId) {
+    return budgets.value[String(categoryId)] ?? 0;
+  }
+
+  function clearBudgets() {
+    budgets.value = {};
+  }
+
+  async function fetchBudgets() {
+    try {
+      const data = await budgetService.fetchAll();
+      // category_id별로 가장 마지막 레코드 기준으로 적용 (중복 방지)
+      console.log(data);
+      budgets.value = data.reduce((acc, b) => {
+        acc[String(b.category_id)] = b.amount;
+        return acc;
+      }, {});
+    } catch (error) {
+      console.error("예산 조회 실패:", error);
+    }
+  }
+
+  async function saveBudgets(draftBudgets) {
+    await budgetService.save(draftBudgets);
+    budgets.value = { ...draftBudgets };
+  }
+
+  const authStore = useAuthStore();
+  watch(
+    () => authStore.user,
+    (newUser) => {
+      if (newUser) {
+        fetchBudgets();
+      } else {
+        clearBudgets();
+      }
+    },
+    { immediate: true },
+  );
+
+  return { budgets, getBudgetAmount, fetchBudgets, saveBudgets, clearBudgets };
+});


### PR DESCRIPTION
## Summary

- `budgets` 컬렉션 추가 및 API/서비스/스토어 계층 구현
- 마이페이지 BudgetSection에서 카테고리별 예산 설정 및 이번 달 실제 지출 비교 UI 제공

## Changes

- **DB**: `budgets` 컬렉션 추가 (`db.json`, `db.dev.json`)
- **API**: `axiosClient`에 `budgetApi` (`getBudgets`, `createBudget`, `updateBudget`) 추가
- **Service**: `budgetService.js` 신규 — 저장 시 서버 조회 후 category_id 기준 PUT/POST 분기
- **Store**: `useBudgetStore.js` 신규 — 로그인 상태 watch로 자동 fetch/clear
- **UI**: `BudgetSection.vue` — 실제 지출 vs 예산 표시, 초과 시 빨간색, 저장 중 상태 처리

## Test plan

- [ ] 마이페이지 > 예산 설정 탭 진입 시 저장된 예산이 올바르게 표시되는지 확인
- [ ] 수정 버튼 클릭 → 카테고리별 금액 입력 → 저장 후 DB 반영 확인
- [ ] 이미 예산이 있는 카테고리 재저장 시 PUT(업데이트)으로 처리되는지 확인
- [ ] 이번 달 지출이 있는 카테고리의 진행 바 및 % 표시 확인
- [ ] 예산 초과 카테고리 빨간색 강조 확인
- [ ] 로그아웃 시 예산 데이터 초기화 확인

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)