### PR TITLE
refactor: 거래내역 페이지 반응형 디자인 수정

### DIFF
--- a/src/components/transaction/TransactionFilter.vue
+++ b/src/components/transaction/TransactionFilter.vue
@@ -1,0 +1,232 @@
+<script setup>
+import { computed, watch } from "vue";
+import { storeToRefs } from "pinia";
+import { useCategoryStore } from "@/stores/categories/useCategoryStore";
+
+const props = defineProps({
+  filters: {
+    type: Object,
+    required: true,
+  },
+});
+const emit = defineEmits(["update:filters"]);
+
+const { categories } = storeToRefs(useCategoryStore());
+
+const filteredCategories = computed(() => {
+  if (!props.filters.type) return categories.value;
+  return categories.value.filter((cat) => cat.type === props.filters.type);
+});
+
+const update = (key, value) => {
+  emit("update:filters", { ...props.filters, [key]: value });
+};
+
+const reset = () => {
+  emit("update:filters", {
+    startDate: "",
+    endDate: "",
+    categoryId: "",
+    type: "",
+    keyword: "",
+  });
+};
+
+// 분류 변경 시 해당 분류에 속하지 않는 카테고리가 선택된 경우 초기화
+watch(
+  () => props.filters.type,
+  (newType) => {
+    if (!newType) return;
+    const selected = categories.value.find(
+      (cat) => cat.id === props.filters.categoryId,
+    );
+    if (selected && selected.type !== newType) {
+      emit("update:filters", {
+        ...props.filters,
+        type: newType,
+        categoryId: "",
+      });
+    }
+  },
+);
+</script>
+
+<template>
+  <section class="filter-section">
+    <div class="filter-row">
+      <div class="filter-group">
+        <label>시작일</label>
+        <input
+          type="date"
+          :value="filters.startDate"
+          @change="update('startDate', $event.target.value)"
+          class="filter-input"
+        />
+      </div>
+      <div class="filter-group">
+        <label>종료일</label>
+        <input
+          type="date"
+          :value="filters.endDate"
+          @change="update('endDate', $event.target.value)"
+          class="filter-input"
+        />
+      </div>
+
+      <div class="filter-group">
+        <label>분류</label>
+        <select
+          :value="filters.type"
+          @change="update('type', $event.target.value)"
+          class="filter-input"
+        >
+          <option value="">전체</option>
+          <option value="INCOME">수입</option>
+          <option value="EXPENSE">지출</option>
+        </select>
+      </div>
+
+      <div class="filter-group">
+        <label>카테고리</label>
+        <select
+          :value="filters.categoryId"
+          @change="update('categoryId', $event.target.value)"
+          class="filter-input"
+        >
+          <option value="">전체</option>
+          <option
+            v-for="cat in filteredCategories"
+            :key="cat.id"
+            :value="cat.id"
+          >
+            {{ cat.name }}
+          </option>
+        </select>
+      </div>
+
+      <div class="filter-group search-group">
+        <label>항목</label>
+        <input
+          type="text"
+          :value="filters.keyword"
+          @input="update('keyword', $event.target.value)"
+          placeholder="거래 항목 검색"
+          class="filter-input"
+        />
+      </div>
+
+      <button class="reset-btn" @click="reset" title="필터 초기화">
+        <i class="fas fa-rotate-left"></i> 초기화
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.filter-section {
+  background: #ffffff;
+  padding: 20px 24px;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.02);
+  margin-bottom: 24px;
+}
+.filter-row {
+  display: flex;
+  gap: 20px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+.filter-group {
+  display: flex;
+  flex-direction: column;
+}
+.filter-group label {
+  font-size: 12px;
+  color: #64748b;
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+.filter-input {
+  padding: 10px 14px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #334155;
+  outline: none;
+  min-width: 140px;
+  transition: border-color 0.2s;
+}
+.filter-input:focus {
+  border-color: #00c853;
+}
+.search-group {
+  min-width: 200px;
+  max-width: 240px;
+}
+.reset-btn {
+  align-self: flex-end;
+  background-color: #f1f5f9;
+  color: #64748b;
+  border: none;
+  border-radius: 8px;
+  padding: 0 16px;
+  height: 41px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
+  white-space: nowrap;
+}
+.reset-btn:hover {
+  background-color: #e2e8f0;
+  color: #334155;
+}
+
+@media (max-width: 768px) {
+  .filter-section {
+    padding: 16px;
+    margin-bottom: 16px;
+    border: none;
+  }
+
+  .filter-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+
+  .search-group {
+    grid-column: span 2;
+    max-width: none;
+  }
+
+  .reset-btn {
+    grid-column: span 2;
+    justify-content: center;
+    width: 100%;
+    height: 40px;
+  }
+
+  .filter-group label {
+    font-size: 11px;
+    margin-bottom: 4px;
+  }
+
+  .filter-group {
+    min-width: 0;
+  }
+
+  .filter-input {
+    padding: 8px 12px;
+    font-size: 13px;
+    height: 40px;
+    min-width: 0;
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/transaction/TransactionItem.vue
+++ b/src/components/transaction/TransactionItem.vue
@@ -1,0 +1,463 @@
+<script setup>
+import { ref } from "vue";
+import { storeToRefs } from "pinia";
+import { useCategoryStore } from "@/stores/categories/useCategoryStore";
+import { useAddTransactionStore } from "@/stores/transactions/useAddTransactionStore";
+import { formatAmountShort } from "@/utils/formatter";
+import { Payments } from "@/constant/paymentMethods";
+
+const props = defineProps({
+  item: { type: Object, required: true },
+  date: { type: String, required: true },
+});
+const emit = defineEmits(["request-delete"]);
+
+const { getCategoryById } = useCategoryStore();
+const getCat = (id) => getCategoryById(id);
+
+const { openEditModal } = useAddTransactionStore();
+
+const isExpanded = ref(false);
+
+const formatAmountDisplay = (amt) =>
+  amt >= 100_000_000
+    ? formatAmountShort(amt)
+    : new Intl.NumberFormat("ko-KR").format(amt) + "원";
+
+const formatAmount = (amt, type) => {
+  const formatted = formatAmountDisplay(Math.abs(amt));
+  return type === "INCOME" ? `+${formatted}` : `-${formatted}`;
+};
+const formatAmountMobile = formatAmount;
+const formatExpandDate = (dateStr, time) => {
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}월 ${d.getDate()}일 ${time}`;
+};
+
+const getPayment = (method) =>
+  Object.values(Payments).find((p) => p.value === method);
+</script>
+
+<template>
+  <div class="transaction-item">
+    <div class="col-detail detail-wrap">
+      <div
+        class="item-icon"
+        :style="{
+          color: getCat(item.category_id).color,
+          backgroundColor: getCat(item.category_id).subColor,
+        }"
+      >
+        <i :class="getCat(item.category_id).icon"></i>
+      </div>
+      <div class="item-info">
+        <div class="item-title">{{ item.detail }}</div>
+        <div class="item-memo" v-if="item.memo">{{ item.memo }}</div>
+      </div>
+    </div>
+
+    <div class="col-category">
+      <span
+        class="category-tag"
+        :style="{
+          color: getCat(item.category_id).color,
+          backgroundColor: getCat(item.category_id).subColor,
+        }"
+      >
+        {{ getCat(item.category_id).name }}
+      </span>
+    </div>
+
+    <div class="col-date time-text pc-only">
+      <i class="far fa-clock"></i> {{ date }}
+    </div>
+
+    <div
+      class="col-amount amount-text"
+      :class="item.type === 'INCOME' ? 'text-blue' : 'text-red'"
+    >
+      <span class="pc-only">{{ formatAmount(item.amount, item.type) }}</span>
+      <span class="mobile-only">{{
+        formatAmountMobile(item.amount, item.type)
+      }}</span>
+    </div>
+
+    <div class="col-action">
+      <button
+        class="action-btn pc-only"
+        @click="openEditModal(item)"
+        title="수정"
+      >
+        <i class="far fa-edit"></i>
+      </button>
+      <button
+        class="action-btn pc-only"
+        @click="emit('request-delete', item.id)"
+        title="삭제"
+      >
+        <i class="far fa-trash-alt"></i>
+      </button>
+      <button
+        class="action-btn mobile-only toggle-btn"
+        @click="isExpanded = !isExpanded"
+        :class="{ open: isExpanded }"
+      >
+        <i class="fas fa-chevron-down"></i>
+      </button>
+    </div>
+
+    <transition name="slide-down">
+      <div v-if="isExpanded" class="item-expanded mobile-only">
+        <div class="expand-info">
+          <div class="expand-row">
+            <span class="expand-label">카테고리</span>
+            <span
+              class="expand-category-tag"
+              :style="{
+                color: getCat(item.category_id).color,
+                backgroundColor: getCat(item.category_id).subColor,
+              }"
+            >
+              <i :class="getCat(item.category_id).icon"></i>
+              {{ getCat(item.category_id).name }}
+            </span>
+          </div>
+          <div class="expand-row">
+            <span class="expand-label">날짜</span>
+            <span class="expand-value">{{
+              formatExpandDate(date, item.displayTime)
+            }}</span>
+          </div>
+          <div class="expand-row">
+            <span class="expand-label">금액</span>
+            <span
+              class="expand-value"
+              :class="item.type === 'INCOME' ? 'text-blue' : 'text-red'"
+            >
+              {{ formatAmount(item.amount, item.type) }}
+            </span>
+          </div>
+          <div class="expand-row" v-if="item.method">
+            <span class="expand-label">결제수단</span>
+            <span class="expand-value">
+              <i
+                :class="getPayment(item.method)?.icon"
+                :style="{ color: getPayment(item.method)?.color }"
+              ></i>
+              {{ getPayment(item.method)?.name ?? item.method }}
+            </span>
+          </div>
+          <div class="expand-row" v-if="item.memo">
+            <span class="expand-label">메모</span>
+            <span class="expand-value memo-value">{{ item.memo }}</span>
+          </div>
+        </div>
+        <div class="expand-actions">
+          <button class="expand-action-btn edit" @click="openEditModal(item)">
+            <i class="far fa-edit"></i> 수정
+          </button>
+          <button
+            class="expand-action-btn delete"
+            @click="emit('request-delete', item.id)"
+          >
+            <i class="far fa-trash-alt"></i> 삭제
+          </button>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.transaction-item {
+  display: flex;
+  align-items: center;
+  padding: 16px 0;
+  border-bottom: 1px solid #f9f9f9;
+}
+.transaction-item:last-child {
+  border-bottom: none;
+}
+.col-detail {
+  flex: 3;
+}
+.col-category {
+  flex: 1.5;
+  text-align: center;
+}
+.col-date {
+  flex: 2;
+  text-align: center;
+}
+.col-amount {
+  flex: 1.5;
+  text-align: right;
+}
+.col-action {
+  flex: 1;
+  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.detail-wrap {
+  display: flex;
+  align-items: center;
+}
+.item-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 16px;
+  font-size: 18px;
+}
+.item-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.item-title {
+  font-weight: 600;
+  font-size: 15px;
+  color: #333;
+}
+.item-memo {
+  font-size: 12px;
+  color: #999;
+  margin-top: 4px;
+}
+.category-tag {
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.time-text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #a0abbc;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+.time-text i {
+  margin-right: 6px;
+  font-size: 14px;
+  color: #b0bccd;
+}
+.amount-text {
+  font-weight: 700;
+  font-size: 15px;
+}
+.action-btn {
+  width: 36px;
+  height: 36px;
+  background-color: #ffffff;
+  border: 1.5px solid #eef2f6;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #a0aec0;
+  font-size: 15px;
+  transition: all 0.2s ease;
+}
+.action-btn:hover {
+  border-color: #cbd5e1;
+  color: #64748b;
+  background-color: #f8fafc;
+}
+.text-blue {
+  color: #00b0ff;
+}
+.text-red {
+  color: #ff5252;
+}
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .pc-only {
+    display: none;
+  }
+  .mobile-only {
+    display: inline;
+  }
+
+  .transaction-item {
+    display: grid;
+    grid-template-areas:
+      "detail amount action"
+      "expanded expanded expanded";
+    grid-template-columns: 1fr 140px auto;
+    gap: 0;
+    padding: 12px 0;
+    align-items: center;
+  }
+
+  .col-detail {
+    grid-area: detail;
+    min-width: 0;
+  }
+  .col-amount {
+    grid-area: amount;
+    font-size: 16px;
+    text-align: right;
+    word-break: break-all;
+  }
+  .col-category {
+    display: none;
+  }
+  .col-action {
+    grid-area: action;
+    justify-content: flex-end;
+  }
+
+  .detail-wrap {
+    min-width: 0;
+  }
+
+  .item-info {
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    overflow: hidden;
+  }
+  .item-memo {
+    display: none;
+  }
+  .item-title {
+    font-size: 16px;
+    font-weight: 700;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .category-tag {
+    padding: 4px 10px;
+    font-size: 11px;
+  }
+
+  .toggle-btn {
+    display: flex;
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 4px;
+    width: auto;
+    height: auto;
+    color: #94a3b8;
+    font-size: 12px;
+  }
+  .toggle-btn i {
+    transition: transform 0.2s ease;
+  }
+  .toggle-btn.open i {
+    transform: rotate(180deg);
+  }
+
+  .item-expanded {
+    grid-area: expanded;
+    margin-top: 10px;
+    padding-top: 12px;
+    border-top: 1px solid #f1f5f9;
+  }
+
+  .expand-info {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .expand-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+  }
+  .expand-label {
+    width: 56px;
+    flex-shrink: 0;
+    color: #94a3b8;
+    font-size: 12px;
+  }
+  .expand-value {
+    color: #334155;
+    font-weight: 500;
+  }
+  .expand-value i {
+    margin-right: 4px;
+  }
+  .memo-value {
+    color: #64748b;
+    font-style: italic;
+  }
+
+  .expand-category-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .expand-category-tag i {
+    font-size: 11px;
+  }
+
+  .expand-actions {
+    display: flex;
+    gap: 8px;
+  }
+  .expand-action-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 9px 0;
+    border-radius: 8px;
+    border: none;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .expand-action-btn.edit {
+    background: #f1f5f9;
+    color: #475569;
+  }
+  .expand-action-btn.delete {
+    background: #fff1f2;
+    color: #ef4444;
+  }
+
+  .slide-down-enter-active,
+  .slide-down-leave-active {
+    transition: all 0.2s ease;
+    overflow: hidden;
+  }
+  .slide-down-enter-from,
+  .slide-down-leave-to {
+    opacity: 0;
+    max-height: 0;
+    padding-top: 0;
+    margin-top: 0;
+  }
+  .slide-down-enter-to,
+  .slide-down-leave-from {
+    opacity: 1;
+    max-height: 60px;
+  }
+}
+</style>

--- a/src/components/transaction/TransactionList.vue
+++ b/src/components/transaction/TransactionList.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { ref, computed } from 'vue';
-import { useCategoryStore } from '@/stores/categories/useCategoryStore';
-import DeleteConfirmModal from '../../components/transaction/DeleteConfirmModal.vue';
-import { useAddTransactionStore } from '@/stores/transactions/useAddTransactionStore';
+import { ref, computed } from "vue";
+import { useTransactionStore } from "@/stores/transactions/useTransactionStore";
+import DeleteConfirmModal from "@/components/transaction/DeleteConfirmModal.vue";
+import TransactionItem from "@/components/transaction/TransactionItem.vue";
 
 const props = defineProps({
   transactions: {
@@ -10,37 +10,29 @@ const props = defineProps({
     default: () => [],
   },
 });
-const emit = defineEmits(['edit', 'delete']);
 
-const categoryStore = useCategoryStore();
-const getCat = (id) => categoryStore.getCategoryById(id);
+const { deleteTransaction } = useTransactionStore();
 
-// 데이터 그룹화 및 가공
+// 데이터 그룹화
 const groupedTransactions = computed(() => {
   const groups = {};
 
   props.transactions.forEach((tx) => {
     const dateObj = new Date(tx.transacted_at);
-    // YYYY-MM-DD 형식
-    const dateKey = `${dateObj.getFullYear()}-${String(dateObj.getMonth() + 1).padStart(2, '0')}-${String(dateObj.getDate()).padStart(2, '0')}`;
-
-    // 24시간 형식 표기 (getHours는 0~23을 반환)
-    const timeStr = `${String(dateObj.getHours()).padStart(2, '0')}:${String(dateObj.getMinutes()).padStart(2, '0')}`;
+    const dateKey = `${dateObj.getFullYear()}-${String(dateObj.getMonth() + 1).padStart(2, "0")}-${String(dateObj.getDate()).padStart(2, "0")}`;
+    const timeStr = `${String(dateObj.getHours()).padStart(2, "0")}:${String(dateObj.getMinutes()).padStart(2, "0")}`;
 
     if (!groups[dateKey])
       groups[dateKey] = { date: dateKey, items: [], income: 0, expense: 0 };
     groups[dateKey].items.push({ ...tx, displayTime: timeStr });
 
-    if (tx.type === 'INCOME') groups[dateKey].income += tx.amount;
-    if (tx.type === 'EXPENSE') groups[dateKey].expense += tx.amount;
+    if (tx.type === "INCOME") groups[dateKey].income += tx.amount;
+    if (tx.type === "EXPENSE") groups[dateKey].expense += tx.amount;
   });
 
-  // 1. 날짜별 그룹 정렬 (최신 날짜가 위로)
   const sortedGroups = Object.values(groups).sort(
     (a, b) => new Date(b.date) - new Date(a.date),
   );
-
-  // 2. 각 날짜 그룹 내부의 아이템들을 이름순으로 정렬
   sortedGroups.forEach((group) => {
     group.items.sort((a, b) => a.detail.localeCompare(b.detail));
   });
@@ -48,19 +40,13 @@ const groupedTransactions = computed(() => {
   return sortedGroups;
 });
 
-const formatCurrency = (val) => new Intl.NumberFormat('ko-KR').format(val);
-
-// 포맷팅 함수
-const formatAmount = (amt, type) => {
-  const formatted = new Intl.NumberFormat('ko-KR').format(amt);
-  return type === 'INCOME' ? `+${formatted}원` : `-${formatted}원`;
-};
+const formatCurrency = (val) => new Intl.NumberFormat("ko-KR").format(val);
 const formatDate = (dateStr) => {
   const d = new Date(dateStr);
-  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${['일', '월', '화', '수', '목', '금', '토'][d.getDay()]})`;
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${["일", "월", "화", "수", "목", "금", "토"][d.getDay()]})`;
 };
 
-// 삭제 모달 관련 로직
+// 삭제 모달
 const isDeleteModalOpen = ref(false);
 const targetIdToDelete = ref(null);
 
@@ -73,16 +59,11 @@ const handleCloseDeleteModal = () => {
   targetIdToDelete.value = null;
 };
 const executeDelete = () => {
-  emit('delete', targetIdToDelete.value); // 부모에게 최종 삭제 요청
+  deleteTransaction(targetIdToDelete.value);
   handleCloseDeleteModal();
 };
-
-const updateTransactionStore = useAddTransactionStore();
-const handleEditClick = (item) => {
-  console.log('수정 버튼 눌림! 데이터:', item);
-  updateTransactionStore.openEditModal(item);
-};
 </script>
+
 <template>
   <div class="transaction-container">
     <div class="list-header pc-only">
@@ -110,66 +91,15 @@ const handleEditClick = (item) => {
         </div>
       </div>
 
-      <div v-for="item in group.items" :key="item.id" class="transaction-item">
-        <div class="col-detail detail-wrap">
-          <div
-            class="item-icon"
-            :style="{
-              color: getCat(item.category_id).color,
-              backgroundColor: getCat(item.category_id).subColor,
-            }"
-          >
-            <i :class="getCat(item.category_id).icon"></i>
-          </div>
-          <div class="item-info">
-            <div class="item-title">{{ item.detail }}</div>
-            <div class="item-memo" v-if="item.memo">{{ item.memo }}</div>
-          </div>
-        </div>
-
-        <div class="col-category">
-          <span
-            class="category-tag"
-            :style="{
-              color: getCat(item.category_id).color,
-              backgroundColor: getCat(item.category_id).subColor,
-            }"
-          >
-            {{ getCat(item.category_id).name }}
-          </span>
-        </div>
-
-        <div class="col-date time-text pc-only">
-          <i class="far fa-clock"></i> {{ group.date }}
-        </div>
-
-        <div
-          class="col-amount amount-text"
-          :class="item.type === 'INCOME' ? 'text-blue' : 'text-red'"
-        >
-          {{ formatAmount(item.amount, item.type) }}
-        </div>
-
-        <div class="col-action">
-          <button
-            class="action-btn"
-            @click="handleEditClick(item)"
-            title="수정"
-          >
-            <i class="far fa-edit"></i>
-          </button>
-          <button
-            class="action-btn"
-            @click="handleOpenDeleteModal(item.id)"
-            title="삭제"
-          >
-            <i class="far fa-trash-alt"></i>
-          </button>
-        </div>
-      </div>
+      <TransactionItem
+        v-for="item in group.items"
+        :key="item.id"
+        :item="item"
+        :date="group.date"
+        @request-delete="handleOpenDeleteModal"
+      />
     </div>
 
-    <!-- 데이터가 없을 때 표시할 UI -->
     <div v-if="groupedTransactions.length === 0" class="empty-msg">
       <i class="fa-regular fa-folder-open"></i>
       <p>데이터가 없습니다.</p>
@@ -182,6 +112,7 @@ const handleEditClick = (item) => {
     />
   </div>
 </template>
+
 <style scoped>
 .transaction-container {
   background: #ffffff;
@@ -190,10 +121,13 @@ const handleEditClick = (item) => {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
   position: relative;
 }
-.list-header,
-.transaction-item {
+.list-header {
   display: flex;
   align-items: center;
+  padding: 16px 0;
+  border-bottom: 1px solid #f0f0f0;
+  font-size: 13px;
+  color: #888;
 }
 .col-detail {
   flex: 3;
@@ -213,16 +147,8 @@ const handleEditClick = (item) => {
 .col-action {
   flex: 1;
   text-align: right;
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
 }
-.list-header {
-  padding: 16px 0;
-  border-bottom: 1px solid #f0f0f0;
-  font-size: 13px;
-  color: #888;
-}
+
 .date-group {
   margin-top: 24px;
 }
@@ -241,85 +167,6 @@ const handleEditClick = (item) => {
   font-size: 14px;
   font-weight: 700;
 }
-.transaction-item {
-  padding: 16px 0;
-  border-bottom: 1px solid #f9f9f9;
-}
-.transaction-item:last-child {
-  border-bottom: none;
-}
-.detail-wrap {
-  display: flex;
-  align-items: center;
-}
-.item-icon {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-right: 16px;
-  font-size: 18px;
-}
-.item-info {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-.item-title {
-  font-weight: 600;
-  font-size: 15px;
-  color: #333;
-}
-.item-memo {
-  font-size: 12px;
-  color: #999;
-  margin-top: 4px;
-}
-.category-tag {
-  padding: 6px 14px;
-  border-radius: 20px;
-  font-size: 12px;
-  font-weight: 600;
-}
-.time-text {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #a0abbc;
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
-}
-.time-text i {
-  margin-right: 6px;
-  font-size: 14px;
-  color: #b0bccd;
-}
-.amount-text {
-  font-weight: 700;
-  font-size: 15px;
-}
-.action-btn {
-  width: 36px;
-  height: 36px;
-  background-color: #ffffff;
-  border: 1.5px solid #eef2f6;
-  border-radius: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: #a0aec0;
-  font-size: 15px;
-  transition: all 0.2s ease;
-}
-.action-btn:hover {
-  border-color: #cbd5e1;
-  color: #64748b;
-  background-color: #f8fafc;
-}
 .text-blue {
   color: #00b0ff;
 }
@@ -327,7 +174,6 @@ const handleEditClick = (item) => {
   color: #ff5252;
 }
 
-/* 빈 데이터 안내 메시지 스타일 (Statistic과 동일한 느낌) */
 .empty-msg {
   display: flex;
   flex-direction: column;
@@ -346,88 +192,45 @@ const handleEditClick = (item) => {
   font-size: 1rem;
 }
 
-.mobile-only {
-  display: none;
-}
-
 @media (max-width: 768px) {
   .pc-only {
     display: none;
   }
-  .mobile-only {
-    display: block;
-  }
 
   .transaction-container {
-    padding: 0 16px 16px 16px; /* 모바일에서 여백 살짝 축소 */
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
   }
 
-  /* 1. 리스트 아이템을 카드 형태로 변경 */
-  .transaction-item {
-    display: grid;
-    grid-template-areas: 'detail amount action'; /* 완벽한 1줄 배치로 변경 */
-    grid-template-columns: 1fr auto auto;
-    gap: 8px;
-    padding: 12px 0;
-    align-items: center;
-  }
-
-  /* 2. 각 구역 배치 설정 */
-  .col-detail {
-    grid-area: detail;
-    width: 100%;
-  }
-
-  .col-amount {
-    grid-area: amount;
-    width: auto;
-    font-size: 16px;
-  }
-
-  .col-category {
-    display: none; /* 모바일 화면에서는 카테고리 숨김 */
-  }
-
-  .col-action {
-    grid-area: action;
-    justify-content: flex-end;
-  }
-
-  /* 상세 내용(디테일)과 메모를 양옆으로 나란히 배치 */
-  .item-info {
-    flex-direction: row;
-    align-items: center;
-    gap: 4px;
-  }
-  .item-memo {
-    display: none; /* 모바일에서 메모 숨김 */
-  }
-
-  /* 3. 모바일 전용 폰트 스타일 */
-  .mobile-date {
-    font-size: 12px;
-    color: #a0abbc;
-    margin-top: 2px;
-  }
-
-  .item-title {
-    font-size: 16px; /* 상세내용 글씨 크기 확대 */
-    font-weight: 700; /* 조금 더 또렷하게 보이도록 굵기 추가 (선택사항) */
-  }
-
-  .category-tag {
-    padding: 4px 10px;
-    font-size: 11px;
+  .date-group {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+    padding: 0 16px 8px;
+    margin-top: 0;
   }
 
   .date-header {
-    font-size: 14px; /* 글자 크기 살짝 키움 */
-    padding: 16px 4px; /* 위아래 여백을 대폭 늘려 칸을 넓힘 */
-    margin-bottom: 8px;
-    background-color: #fff;
-    position: sticky;
-    top: 0;
-    z-index: 10;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    padding: 14px 0 10px;
+    margin-bottom: 0;
+    border-bottom: 1px solid #f1f5f9;
+  }
+
+  .date-summary {
+    display: flex;
+    gap: 8px;
+  }
+  .date-summary span {
+    font-size: 12px;
+    font-weight: 600;
+    margin-left: 0;
   }
 }
 </style>

--- a/src/components/transaction/TransactionPagination.vue
+++ b/src/components/transaction/TransactionPagination.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { computed } from 'vue';
+
+const PAGE_GROUP_SIZE = 10;
+
+const props = defineProps({
+  currentPage: {
+    type: Number,
+    required: true,
+  },
+  totalPages: {
+    type: Number,
+    required: true,
+  },
+});
+const emit = defineEmits(['update:currentPage']);
+
+const startPage = computed(
+  () => Math.floor((props.currentPage - 1) / PAGE_GROUP_SIZE) * PAGE_GROUP_SIZE + 1,
+);
+
+const endPage = computed(() => {
+  const end = startPage.value + PAGE_GROUP_SIZE - 1;
+  return end > props.totalPages ? props.totalPages : end;
+});
+
+const pageNumbers = computed(() => {
+  const nums = [];
+  for (let i = startPage.value; i <= endPage.value; i++) {
+    nums.push(i);
+  }
+  return nums;
+});
+
+const go = (page) => emit('update:currentPage', page);
+</script>
+
+<template>
+  <div class="pagination" v-if="totalPages > 0">
+    <button
+      :disabled="currentPage === 1"
+      @click="go(1)"
+      class="page-btn"
+      title="처음으로"
+    >
+      <i class="fas fa-angle-double-left"></i>
+    </button>
+
+    <button
+      :disabled="currentPage === 1"
+      @click="go(currentPage - 1)"
+      class="page-btn"
+      title="이전"
+    >
+      <i class="fas fa-angle-left"></i>
+    </button>
+
+    <button
+      v-for="page in pageNumbers"
+      :key="page"
+      @click="go(page)"
+      :class="['page-btn', { active: currentPage === page }]"
+    >
+      {{ page }}
+    </button>
+
+    <button
+      :disabled="currentPage === totalPages"
+      @click="go(currentPage + 1)"
+      class="page-btn"
+      title="다음"
+    >
+      <i class="fas fa-angle-right"></i>
+    </button>
+
+    <button
+      :disabled="currentPage === totalPages"
+      @click="go(totalPages)"
+      class="page-btn"
+      title="끝으로"
+    >
+      <i class="fas fa-angle-double-right"></i>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  margin-top: 30px;
+  padding-bottom: 40px;
+}
+.page-btn {
+  min-width: 34px;
+  height: 34px;
+  border: none;
+  background-color: transparent;
+  color: #718096;
+  font-size: 13px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+.page-btn:hover:not(:disabled) {
+  background-color: transparent;
+  color: #1a202c;
+}
+.page-btn.active {
+  color: #1a202c;
+  font-weight: 800;
+  border-bottom: 3px solid #1a202c;
+}
+.page-btn:disabled {
+  color: #edf2f7;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/transaction/TransactionSummary.vue
+++ b/src/components/transaction/TransactionSummary.vue
@@ -1,0 +1,163 @@
+<script setup>
+defineProps({
+  summary: {
+    type: Object,
+    required: true,
+  },
+});
+
+const formatCurrency = (val) => new Intl.NumberFormat('ko-KR').format(val);
+</script>
+
+<template>
+  <section class="summary-section">
+    <div class="summary-card">
+      <div class="card-icon text-blue">
+        <i class="fas fa-arrow-circle-down"></i>
+      </div>
+      <div class="card-info">
+        <div class="card-title">총 수입</div>
+        <div class="card-value text-blue">+{{ formatCurrency(summary.income) }}원</div>
+      </div>
+    </div>
+
+    <div class="summary-card">
+      <div class="card-icon text-red">
+        <i class="fas fa-arrow-circle-up"></i>
+      </div>
+      <div class="card-info">
+        <div class="card-title">총 지출</div>
+        <div class="card-value text-red">-{{ formatCurrency(summary.expense) }}원</div>
+      </div>
+    </div>
+
+    <div class="summary-card">
+      <div class="card-icon text-green">
+        <i class="fas fa-check-circle"></i>
+      </div>
+      <div class="card-info">
+        <div class="card-title">순이익</div>
+        <div class="card-value text-green">{{ formatCurrency(summary.net) }}원</div>
+      </div>
+    </div>
+
+    <div class="summary-card mini-card">
+      <div class="card-icon text-gray mobile-only">
+        <i class="fas fa-file-alt"></i>
+      </div>
+      <div class="card-info">
+        <div class="card-title">검색 결과</div>
+        <div class="card-value">{{ summary.count }}건</div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.summary-section {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+.summary-card {
+  flex: 1;
+  background: #ffffff;
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.02);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.mini-card {
+  flex: 0.5;
+  justify-content: center;
+}
+.card-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  background-color: #f8fafc;
+}
+.card-icon.text-blue {
+  background-color: #eff6ff;
+}
+.card-icon.text-red {
+  background-color: #fef2f2;
+}
+.card-icon.text-green {
+  background-color: #f0fdf4;
+}
+.card-title {
+  font-size: 13px;
+  color: #64748b;
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+.card-value {
+  font-size: 20px;
+  font-weight: 800;
+}
+.text-blue {
+  color: #3b82f6;
+}
+.text-red {
+  color: #ef4444;
+}
+.text-green {
+  color: #10b981;
+}
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mobile-only {
+    display: flex;
+  }
+
+  .summary-section {
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .summary-card {
+    padding: 12px 16px;
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: 12px;
+  }
+
+  .mini-card {
+    border: 1px solid #f1f5f9;
+  }
+
+  .card-icon {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+
+  .text-gray {
+    color: #94a3b8;
+  }
+
+  .card-info {
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .card-value {
+    font-size: 15px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+</style>

--- a/src/views/ledger/Transactions.vue
+++ b/src/views/ledger/Transactions.vue
@@ -2,26 +2,20 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useTransactionStore } from '@/stores/transactions/useTransactionStore';
-import { useCategoryStore } from '@/stores/categories/useCategoryStore';
 import TransactionList from '@/components/transaction/TransactionList.vue';
 import TransactionAddModal from '@/components/transaction/TransactionAddModal.vue';
-import { useAuthStore } from '@/stores/auth/useAuthStore';
+import TransactionFilter from '@/components/transaction/TransactionFilter.vue';
+import TransactionSummary from '@/components/transaction/TransactionSummary.vue';
+import TransactionPagination from '@/components/transaction/TransactionPagination.vue';
 
-// Pinia Store 연결
 const transactionStore = useTransactionStore();
-const authStore = useAuthStore();
-
-// 데이터(ref)는 storeToRefs로 감싸서 꺼내야 화면이 실시간으로 바뀜
 const { transactions, loading } = storeToRefs(transactionStore);
-const { categories } = storeToRefs(useCategoryStore());
+const { fetchData } = transactionStore;
 
-// 함수(액션)는 그냥 바로 꺼냅니다.
-const { fetchData, deleteTransaction, updateTransaction } = transactionStore;
+onMounted(() => {
+  fetchData();
+});
 
-//로그인한 유저 정보
-const { user } = storeToRefs(authStore);
-
-// 화면 전용 상태 및 로직
 // 필터 상태
 const filters = ref({
   startDate: '',
@@ -31,290 +25,77 @@ const filters = ref({
   keyword: '',
 });
 
-// 페이지네이션 관련 상태
-const currentPage = ref(1); // 현재 페이지
-const itemsPerPage = ref(10); // 한 페이지당 보여줄 개수 (원하는 대로 조절)
-const PAGE_GROUP_SIZE = 10; // 한 번에 보여줄 페이지 번호 개수 (10개)
+// 페이지네이션 상태
+const currentPage = ref(1);
+const itemsPerPage = ref(10);
 
-// 화면이 켜지면 스토어의 fetchData 함수를 실행
-onMounted(() => {
-  fetchData();
-});
+// 필터 변경 시 페이지 초기화
+watch(filters, () => { currentPage.value = 1; }, { deep: true });
 
-// 1. 필터링된 "전체" 데이터 (기존과 동일)
+// 필터링된 전체 데이터
 const allFilteredTransactions = computed(() => {
-  if (!transactions.value) return []; // 데이터가 없을 때 에러가 나지 않도록 방어
+  if (!transactions.value) return [];
 
-  const filtered = transactions.value.filter((tx) => {
-    // 1. 날짜 필터 (한국 시간으로 변환 후 비교)
-    const dateObj = new Date(tx.transacted_at);
-    // YYYY-MM-DD 형태로 예쁘게 만들기 (input type="date"의 형식과 맞추기 위함)
-    const txDate = `${dateObj.getFullYear()}-${String(dateObj.getMonth() + 1).padStart(2, '0')}-${String(dateObj.getDate()).padStart(2, '0')}`;
+  return transactions.value
+    .filter((tx) => {
+      const dateObj = new Date(tx.transacted_at);
+      const txDate = `${dateObj.getFullYear()}-${String(dateObj.getMonth() + 1).padStart(2, '0')}-${String(dateObj.getDate()).padStart(2, '0')}`;
 
-    if (filters.value.startDate && txDate < filters.value.startDate)
-      return false;
-    if (filters.value.endDate && txDate > filters.value.endDate) return false;
-
-    // 2. 카테고리 필터
-    if (filters.value.categoryId && tx.category_id !== filters.value.categoryId)
-      return false;
-
-    // 3. 수입/지출 필터
-    if (filters.value.type && tx.type !== filters.value.type) return false;
-
-    // 4. 검색어 필터 (상세내용 detail에 검색어가 포함되어 있는지 확인)
-    if (filters.value.keyword) {
-      const keyword = filters.value.keyword.toLowerCase();
-      const matchDetail = tx.detail?.toLowerCase().includes(keyword);
-      if (!matchDetail) return false;
-    }
-    return true;
-  });
-  // 최신 날짜(시간)가 위로 오도록 정렬
-  return filtered.sort((a, b) => {
-    return new Date(b.transacted_at) - new Date(a.transacted_at);
-  });
+      if (filters.value.startDate && txDate < filters.value.startDate) return false;
+      if (filters.value.endDate && txDate > filters.value.endDate) return false;
+      if (filters.value.categoryId && tx.category_id !== filters.value.categoryId) return false;
+      if (filters.value.type && tx.type !== filters.value.type) return false;
+      if (filters.value.keyword) {
+        const keyword = filters.value.keyword.toLowerCase();
+        if (!tx.detail?.toLowerCase().includes(keyword)) return false;
+      }
+      return true;
+    })
+    .sort((a, b) => new Date(b.transacted_at) - new Date(a.transacted_at));
 });
 
-// 2. 현재 페이지에 보여줄 데이터 자르기
+// 현재 페이지 데이터
 const pagedTransactions = computed(() => {
   const start = (currentPage.value - 1) * itemsPerPage.value;
-  const end = start + itemsPerPage.value;
-  return allFilteredTransactions.value.slice(start, end);
+  return allFilteredTransactions.value.slice(start, start + itemsPerPage.value);
 });
 
-// 3. 페이지 번호 계산 (10개씩 끊기)
 const totalPages = computed(() =>
   Math.ceil(allFilteredTransactions.value.length / itemsPerPage.value),
 );
 
-const startPage = computed(
-  () =>
-    Math.floor((currentPage.value - 1) / PAGE_GROUP_SIZE) * PAGE_GROUP_SIZE + 1,
-);
-
-const endPage = computed(() => {
-  let end = startPage.value + PAGE_GROUP_SIZE - 1;
-  return end > totalPages.value ? totalPages.value : end;
-});
-
-const pageNumbers = computed(() => {
-  const nums = [];
-  for (let i = startPage.value; i <= endPage.value; i++) {
-    nums.push(i);
-  }
-  return nums;
-});
-
-watch(
-  filters,
-  () => {
-    currentPage.value = 1;
-  },
-  { deep: true },
-);
-
-watch(user, (newUser) => {
-  if (newUser) {
-    fetchData(newUser.id); // 새 유저의 데이터를 가져와!
-  } else {
-    transactions.value = []; // 로그아웃했다면 데이터를 비워!
-  }
-});
-
-// 걸러진 데이터로 합계 계산하기 (기존 로직 완벽히 동일)
 const summary = computed(() => {
   let income = 0;
   let expense = 0;
 
-  if (!transactions.value) return { income: 0, expense: 0, net: 0, count: 0 }; // 방어 코드
-
-  transactions.value.forEach((tx) => {
-    const dateObj = new Date(tx.transacted_at);
-    const txDate = `${dateObj.getFullYear()}-${String(dateObj.getMonth() + 1).padStart(2, '0')}-${String(dateObj.getDate()).padStart(2, '0')}`;
-
-    // 날짜 조건만 확인
-    let isDateValid = true;
-    if (filters.value.startDate && txDate < filters.value.startDate)
-      isDateValid = false;
-    if (filters.value.endDate && txDate > filters.value.endDate)
-      isDateValid = false;
-
-    // 날짜 조건만 맞으면, 검색어나 카테고리에 상관없이 무조건 합산
-    if (isDateValid) {
-      if (tx.type === 'INCOME') income += tx.amount;
-      if (tx.type === 'EXPENSE') expense += tx.amount;
-    }
+  allFilteredTransactions.value.forEach((tx) => {
+    if (tx.type === 'INCOME') income += tx.amount;
+    if (tx.type === 'EXPENSE') expense += tx.amount;
   });
 
   return {
     income,
     expense,
     net: income - expense,
-    count: allFilteredTransactions.value.length, //필터링된 총 개수
+    count: allFilteredTransactions.value.length,
   };
 });
-
-const formatCurrency = (val) => new Intl.NumberFormat('ko-KR').format(val);
 </script>
 
 <template>
   <div class="page-container">
-    <section class="filter-section">
-      <div class="filter-row">
-        <div class="filter-group">
-          <label>시작일</label>
-          <input type="date" v-model="filters.startDate" class="filter-input" />
-        </div>
-        <div class="filter-group">
-          <label>종료일</label>
-          <input type="date" v-model="filters.endDate" class="filter-input" />
-        </div>
+    <TransactionFilter v-model:filters="filters" />
 
-        <div class="filter-group">
-          <label>분류</label>
-          <select v-model="filters.type" class="filter-input">
-            <option value="">전체</option>
-            <option value="INCOME">수입</option>
-            <option value="EXPENSE">지출</option>
-          </select>
-        </div>
+    <TransactionSummary :summary="summary" />
 
-        <div class="filter-group">
-          <label>카테고리</label>
-          <select v-model="filters.categoryId" class="filter-input">
-            <option value="">전체</option>
-            <option v-for="cat in categories" :key="cat.id" :value="cat.id">
-              {{ cat.name }}
-            </option>
-          </select>
-        </div>
-
-        <div class="filter-group search-group">
-          <label>항목</label>
-          <div class="search-input-wrap">
-            <input
-              type="text"
-              v-model="filters.keyword"
-              placeholder="거래 항목 검색"
-              class="filter-input"
-            />
-            <button class="search-btn">
-              <i class="fas fa-search"></i> 조회
-            </button>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="summary-section">
-      <div class="summary-card">
-        <div class="card-icon text-blue">
-          <i class="fas fa-arrow-circle-down"></i>
-        </div>
-        <div class="card-info">
-          <div class="card-title">총 수입</div>
-          <div class="card-value text-blue">
-            +{{ formatCurrency(summary.income) }}원
-          </div>
-        </div>
-      </div>
-
-      <div class="summary-card">
-        <div class="card-icon text-red">
-          <i class="fas fa-arrow-circle-up"></i>
-        </div>
-        <div class="card-info">
-          <div class="card-title">총 지출</div>
-          <div class="card-value text-red">
-            -{{ formatCurrency(summary.expense) }}원
-          </div>
-        </div>
-      </div>
-
-      <div class="summary-card">
-        <div class="card-icon text-green">
-          <i class="fas fa-check-circle"></i>
-        </div>
-        <div class="card-info">
-          <div class="card-title">순이익</div>
-          <div class="card-value text-green">
-            {{ formatCurrency(summary.net) }}원
-          </div>
-        </div>
-      </div>
-
-      <div class="summary-card mini-card">
-        <div class="card-icon text-gray mobile-only">
-          <i class="fas fa-file-alt"></i>
-        </div>
-
-        <div class="card-info">
-          <div class="card-title">검색 결과</div>
-          <div class="card-value">{{ summary.count }}건</div>
-        </div>
-      </div>
-    </section>
-
-    <!-- 로딩 중일 때 표시할 리스트 영역 -->
     <div v-if="loading" class="loading-overlay">
       데이터를 불러오는 중입니다...
     </div>
 
-    <!-- 로딩이 완료되면 보여줄 리스트 및 페이지네이션 -->
     <template v-else>
-      <TransactionList
-        :transactions="pagedTransactions"
-        @delete="deleteTransaction"
-        @edit="updateTransaction"
-      />
+      <TransactionList :transactions="pagedTransactions" />
 
-      <div class="pagination" v-if="totalPages > 0">
-        <button
-          :disabled="currentPage === 1"
-          @click="currentPage = 1"
-          class="page-btn"
-          title="처음으로"
-        >
-          <i class="fas fa-angle-double-left"></i>
-        </button>
-
-        <button
-          :disabled="currentPage === 1"
-          @click="currentPage--"
-          class="page-btn"
-          title="이전"
-        >
-          <i class="fas fa-angle-left"></i>
-        </button>
-
-        <button
-          v-for="page in pageNumbers"
-          :key="page"
-          @click="currentPage = page"
-          :class="['page-btn', { active: currentPage === page }]"
-        >
-          {{ page }}
-        </button>
-
-        <button
-          :disabled="currentPage === totalPages"
-          @click="currentPage++"
-          class="page-btn"
-          title="다음"
-        >
-          <i class="fas fa-angle-right"></i>
-        </button>
-
-        <button
-          :disabled="currentPage === totalPages"
-          @click="currentPage = totalPages"
-          class="page-btn"
-          title="끝으로"
-        >
-          <i class="fas fa-angle-double-right"></i>
-        </button>
-      </div>
+      <TransactionPagination v-model:currentPage="currentPage" :totalPages="totalPages" />
     </template>
 
     <TransactionAddModal />
@@ -322,300 +103,27 @@ const formatCurrency = (val) => new Intl.NumberFormat('ko-KR').format(val);
 </template>
 
 <style scoped>
-/* 페이지 전체 배경 */
 .page-container {
   padding: 32px;
   background-color: #f8fafc;
   min-height: 100vh;
 }
-.page-title {
-  font-size: 22px;
-  font-weight: 700;
-  color: #1e293b;
-  margin: 0 0 8px 0;
-}
-.page-subtitle {
-  color: #64748b;
-  font-size: 14px;
-  margin: 0;
-}
 
-/* 로딩 화면 스타일 */
 .loading-overlay {
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 40vh; /* 상단에 필터와 카드가 있으므로 높이를 살짝 줄임 */
+  min-height: 40vh;
   font-size: 18px;
   font-weight: 700;
   color: #64748b;
 }
 
-/* 1. 필터 섹션 스타일 */
-.filter-section {
-  background: #ffffff;
-  padding: 20px 24px;
-  border-radius: 12px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.02);
-  margin-bottom: 24px;
-}
-.filter-row {
-  display: flex;
-  gap: 20px;
-  align-items: flex-end;
-  flex-wrap: wrap;
-}
-.filter-group {
-  display: flex;
-  flex-direction: column;
-}
-.filter-group label {
-  font-size: 12px;
-  color: #64748b;
-  margin-bottom: 8px;
-  font-weight: 600;
-}
-.filter-input {
-  padding: 10px 14px;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  font-size: 14px;
-  color: #334155;
-  outline: none;
-  min-width: 140px;
-  transition: border-color 0.2s;
-}
-.filter-input:focus {
-  border-color: #00c853;
-}
-
-/* 검색바 & 버튼 영역 */
-.search-group {
-  flex: 1;
-  min-width: 280px;
-}
-.search-input-wrap {
-  display: flex;
-  gap: 8px;
-}
-.search-input-wrap .filter-input {
-  flex: 1;
-}
-.search-btn {
-  background-color: #00c853;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  padding: 0 20px;
-  font-weight: 600;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  transition: background-color 0.2s;
-}
-.search-btn:hover {
-  background-color: #00b34a;
-}
-
-/* 2. 요약 카드 섹션 스타일 */
-.summary-section {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 24px;
-}
-.summary-card {
-  flex: 1;
-  background: #ffffff;
-  padding: 24px;
-  border-radius: 12px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.02);
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-.mini-card {
-  flex: 0.5;
-  justify-content: center;
-} /* 건수 카드는 조금 작게 */
-
-.card-icon {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 24px;
-  background-color: #f8fafc;
-}
-.card-icon.text-blue {
-  background-color: #eff6ff;
-}
-.card-icon.text-red {
-  background-color: #fef2f2;
-}
-.card-icon.text-green {
-  background-color: #f0fdf4;
-}
-
-.card-title {
-  font-size: 13px;
-  color: #64748b;
-  margin-bottom: 6px;
-  font-weight: 600;
-}
-.card-value {
-  font-size: 20px;
-  font-weight: 800;
-}
-
-/* 텍스트 색상 */
-.text-blue {
-  color: #3b82f6;
-}
-.text-red {
-  color: #ef4444;
-}
-.text-green {
-  color: #10b981;
-}
-/* 페이지 네이션 */
-.pagination {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 4px;
-  margin-top: 30px;
-  padding-bottom: 40px;
-}
-
-.page-btn {
-  min-width: 34px;
-  height: 34px;
-  border: none;
-  background-color: transparent;
-  color: #718096;
-  font-size: 13px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s;
-}
-
-.page-btn:hover:not(:disabled) {
-  background-color: transparent;
-  color: #1a202c; /* 마우스 오버 시 배경 대신 아이콘/글자 색상을 진하게 강조 */
-}
-
-.page-btn.active {
-  color: #1a202c;
-  font-weight: 800;
-  border-bottom: 3px solid #1a202c; /* 강조 밑줄 */
-}
-
-.page-btn:disabled {
-  color: #edf2f7;
-  cursor: not-allowed;
-}
-.mobile-only {
-  display: none; /* PC에서는 기본적으로 숨김 */
-}
-
 @media (max-width: 768px) {
-  .mobile-only {
-    display: flex; /* 모바일 화면이 되면 다시 보이게 함 */
-  }
-
   .page-container {
     padding: 12px;
-    background-color: #f1f5f9; /* 배경색을 살짝 진하게 해서 카드를 돋보이게 */
-  }
-
-  /* 1. 필터 섹션 개선 */
-  .filter-section {
-    padding: 16px;
-    margin-bottom: 16px;
-    border: none;
-  }
-
-  .filter-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr; /* 시작일, 종료일을 한 줄에 */
-    gap: 12px;
-  }
-
-  /* 항목(검색) 부분은 한 줄을 통째로 차지하게 */
-  .search-group {
-    grid-column: span 2;
-  }
-
-  .filter-group label {
-    font-size: 11px;
-    margin-bottom: 4px;
-  }
-
-  .filter-input {
-    padding: 8px 12px;
-    font-size: 13px;
-    height: 40px; /* 높이 통일 */
-  }
-
-  .summary-section {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 10px;
-    margin-bottom: 16px;
-  }
-
-  /* 수입/지출/순이익 카드 공통 */
-  .summary-card {
-    padding: 12px;
-    flex-direction: row; /* 아이콘과 텍스트 가로 배치 */
-    justify-content: flex-start;
-    text-align: left;
-    gap: 10px;
-  }
-
-  /* 💡 검색 결과 카드 최적화 */
-  .mini-card {
-    grid-column: span 1; /* 한 칸 차지 (순이익 옆) */
-    margin-top: 0;
-    display: flex;
-    align-items: center; /* 세로 중앙 정렬 */
-    background: #ffffff; /* 다른 카드와 동일하게 흰색 배경 */
-    border: 1px solid #f1f5f9;
-    gap: 10px;
-  }
-
-  /* 💡 검색 결과 아이콘 스타일 */
-  .card-icon {
-    width: 32px; /* 다른 카드보다 약간 작게 설정 */
-    height: 32px;
-    font-size: 14px;
-    background-color: #f1f5f9; /* 배경색 연한 그레이 */
-  }
-
-  .text-gray {
-    color: #94a3b8; /* 아이콘 색상은 차분한 그레이 */
-  }
-
-  /* 내부 텍스트 정렬 */
-  .mini-card .card-info {
-    flex-direction: column;
-    align-items: flex-start; /* 텍스트는 왼쪽 정렬 */
-    gap: 2px;
-  }
-
-  .mini-card .card-title {
-    font-size: 11px;
-    margin-bottom: 0;
-  }
-
-  .mini-card .card-value {
-    font-size: 14px;
-    font-weight: 700;
+    background-color: #f1f5f9;
+    overflow-x: hidden;
   }
 }
 </style>


### PR DESCRIPTION
## 요약
- 거래내역 페이지를 반응형 중심으로 재구성했습니다.
- 필터, 요약, 페이지네이션, 개별 거래 아이템 UI를 별도 컴포넌트로 분리했습니다.
- 모바일에서 거래 항목을 확장해 상세 정보와 수정/삭제 액션을 볼 수 있도록 개선했습니다.

## 변경 이유
- 기존 `Transactions` 뷰에 UI와 스타일이 집중되어 있어 모바일 대응과 구조 확장이 어렵던 문제를 줄이기 위해서입니다.

## 영향
- 거래내역 페이지의 데스크톱/모바일 레이아웃이 달라집니다.
- 필터, 요약, 리스트, 페이지네이션 변경을 각각 독립적으로 수정하기 쉬워집니다.

## 검증
- `npm run build`

Closes #110
