### PR TITLE
refactor: 결제수단 저장 방식 변경

### DIFF
--- a/server/db.dev.json
+++ b/server/db.dev.json
@@ -1,7 +1,7 @@
 {
   "members": [
     {
-      "id": 1,
+      "id": "1",
       "email": "test@example.com",
       "password": "test1234@",
       "name": "테스트 유저",
@@ -10,497 +10,574 @@
   ],
   "categories": [
     {
-      "id": 1,
+      "id": "1",
       "code": "FOOD",
       "name": "식비",
       "type": "EXPENSE"
     },
     {
-      "id": 2,
+      "id": "2",
       "code": "CAFE",
       "name": "카페",
       "type": "EXPENSE"
     },
     {
-      "id": 3,
+      "id": "3",
       "code": "TRANSPORT",
       "name": "교통",
       "type": "EXPENSE"
     },
     {
-      "id": 4,
+      "id": "4",
       "code": "SHOPPING",
       "name": "쇼핑",
       "type": "EXPENSE"
     },
     {
-      "id": 5,
+      "id": "5",
       "code": "GROCERIES",
       "name": "식료품",
       "type": "EXPENSE"
     },
     {
-      "id": 6,
+      "id": "6",
       "code": "SUBSCRIPTION",
       "name": "구독",
       "type": "EXPENSE"
     },
     {
-      "id": 7,
+      "id": "7",
       "code": "HEALTH",
       "name": "건강",
       "type": "EXPENSE"
     },
     {
-      "id": 8,
+      "id": "8",
       "code": "EDUCATION",
       "name": "교육",
       "type": "EXPENSE"
     },
     {
-      "id": 9,
+      "id": "9",
       "code": "LEISURE",
       "name": "여가",
       "type": "EXPENSE"
     },
     {
-      "id": 10,
+      "id": "10",
       "code": "ETC_EXPENSE",
       "name": "기타",
       "type": "EXPENSE"
     },
     {
-      "id": 11,
+      "id": "11",
       "code": "SALARY",
       "name": "급여",
       "type": "INCOME"
     },
     {
-      "id": 12,
+      "id": "12",
       "code": "SIDE_JOB",
       "name": "부업",
       "type": "INCOME"
     },
     {
-      "id": 13,
+      "id": "13",
       "code": "INVESTMENT",
       "name": "투자",
       "type": "INCOME"
     },
     {
-      "id": 14,
+      "id": "14",
       "code": "ALLOWANCE",
       "name": "용돈",
       "type": "INCOME"
     },
     {
-      "id": 15,
+      "id": "15",
       "code": "ETC_INCOME",
       "name": "기타",
       "type": "INCOME"
     }
   ],
+  "payments": [
+    {
+      "id": 1,
+      "code": "CREDIT_CARD",
+      "name": "신용카드"
+    },
+    {
+      "id": 2,
+      "code": "CHECK_CARD",
+      "name": "체크카드"
+    },
+    {
+      "id": 3,
+      "code": "CASH",
+      "name": "현금"
+    },
+    {
+      "id": 4,
+      "code": "BANK_TRANSFER",
+      "name": "계좌이체"
+    },
+    {
+      "id": 5,
+      "code": "EASY_PAY",
+      "name": "간편결제"
+    }
+  ],
   "budgets": [
     {
-      "user_id": 1,
-      "category_id": 1,
-      "amount": 1000000,
+      "user_id": "1",
+      "category_id": "1",
+      "amount": 10000,
       "id": 1
     },
     {
-      "user_id": 1,
-      "category_id": 2,
+      "user_id": "1",
+      "category_id": "2",
       "amount": 0,
       "id": 2
     },
     {
-      "user_id": 1,
-      "category_id": 3,
+      "user_id": "1",
+      "category_id": "3",
       "amount": 50000,
       "id": 3
     },
     {
-      "user_id": 1,
-      "category_id": 4,
+      "user_id": "1",
+      "category_id": "4",
       "amount": 0,
       "id": 4
     },
     {
-      "user_id": 1,
-      "category_id": 5,
+      "user_id": "1",
+      "category_id": "5",
       "amount": 0,
       "id": 5
     },
     {
-      "user_id": 1,
-      "category_id": 6,
+      "user_id": "1",
+      "category_id": "6",
       "amount": 0,
       "id": 6
     },
     {
-      "user_id": 1,
-      "category_id": 7,
+      "user_id": "1",
+      "category_id": "7",
       "amount": 0,
       "id": 7
     },
     {
-      "user_id": 1,
-      "category_id": 8,
+      "user_id": "1",
+      "category_id": "8",
       "amount": 0,
       "id": 8
     },
     {
-      "user_id": 1,
-      "category_id": 9,
+      "user_id": "1",
+      "category_id": "9",
       "amount": 0,
       "id": 9
     },
     {
-      "user_id": 1,
-      "category_id": 10,
+      "user_id": "1",
+      "category_id": "10",
       "amount": 0,
       "id": 10
     }
   ],
   "transactions": [
     {
-      "id": 1,
+      "id": "1",
       "user_id": 1,
       "type": "INCOME",
       "amount": 3000000,
       "category_id": 11,
       "detail": "2월 급여",
       "memo": "",
-      "method": "TRANSFER",
       "transacted_at": "2026-02-01T09:00:00.000Z",
-      "created_at": "2026-02-01T09:00:00.000Z"
+      "created_at": "2026-02-01T09:00:00.000Z",
+      "payment": null
     },
     {
-      "id": 2,
+      "id": "2",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 9500,
       "category_id": 1,
       "detail": "점심 식사",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-02-03T12:30:00.000Z",
-      "created_at": "2026-02-03T12:30:00.000Z"
+      "created_at": "2026-02-03T12:30:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 3,
+      "id": "3",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 4500,
       "category_id": 2,
       "detail": "아메리카노",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-02-05T08:45:00.000Z",
-      "created_at": "2026-02-05T08:45:00.000Z"
+      "created_at": "2026-02-05T08:45:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 4,
+      "id": "4",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 13900,
       "category_id": 6,
       "detail": "넷플릭스",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-02-10T00:00:00.000Z",
-      "created_at": "2026-02-10T00:00:00.000Z"
+      "created_at": "2026-02-10T00:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 5,
+      "id": "5",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 52000,
       "category_id": 5,
       "detail": "마트 장보기",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-02-15T16:00:00.000Z",
-      "created_at": "2026-02-15T16:00:00.000Z"
+      "created_at": "2026-02-15T16:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 6,
+      "id": "6",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 3000,
       "category_id": 3,
       "detail": "지하철",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-02-18T07:30:00.000Z",
-      "created_at": "2026-02-18T07:30:00.000Z"
+      "created_at": "2026-02-18T07:30:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 7,
+      "id": "7",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 120000,
       "category_id": 4,
       "detail": "겨울 옷 정리",
       "memo": "세일 구매",
-      "method": "CARD",
       "transacted_at": "2026-02-22T14:00:00.000Z",
-      "created_at": "2026-02-22T14:00:00.000Z"
+      "created_at": "2026-02-22T14:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 8,
+      "id": "8",
       "user_id": 1,
       "type": "INCOME",
       "amount": 3000000,
       "category_id": 11,
       "detail": "3월 급여",
       "memo": "",
-      "method": "TRANSFER",
       "transacted_at": "2026-03-01T09:00:00.000Z",
-      "created_at": "2026-03-01T09:00:00.000Z"
+      "created_at": "2026-03-01T09:00:00.000Z",
+      "payment": null
     },
     {
-      "id": 9,
+      "id": "9",
       "user_id": 1,
       "type": "INCOME",
       "amount": 300000,
       "category_id": 12,
       "detail": "프리랜서 수입",
       "memo": "",
-      "method": "TRANSFER",
       "transacted_at": "2026-03-05T10:00:00.000Z",
-      "created_at": "2026-03-05T10:00:00.000Z"
+      "created_at": "2026-03-05T10:00:00.000Z",
+      "payment": null
     },
     {
-      "id": 10,
+      "id": "10",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 11000,
       "category_id": 1,
       "detail": "저녁 식사",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-03-07T19:00:00.000Z",
-      "created_at": "2026-03-07T19:00:00.000Z"
+      "created_at": "2026-03-07T19:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 11,
+      "id": "11",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 5500,
       "category_id": 2,
       "detail": "카페라떼",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-03-10T09:00:00.000Z",
-      "created_at": "2026-03-10T09:00:00.000Z"
+      "created_at": "2026-03-10T09:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 12,
+      "id": "12",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 13900,
       "category_id": 6,
       "detail": "넷플릭스",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-03-10T00:00:00.000Z",
-      "created_at": "2026-03-10T00:00:00.000Z"
+      "created_at": "2026-03-10T00:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 13,
+      "id": "13",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 25000,
       "category_id": 7,
       "detail": "병원비",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-03-14T11:00:00.000Z",
-      "created_at": "2026-03-14T11:00:00.000Z"
+      "created_at": "2026-03-14T11:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 14,
+      "id": "14",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 48000,
       "category_id": 5,
       "detail": "마트 장보기",
       "memo": "",
-      "method": "CASH",
       "transacted_at": "2026-03-20T15:00:00.000Z",
-      "created_at": "2026-03-20T15:00:00.000Z"
+      "created_at": "2026-03-20T15:00:00.000Z",
+      "payment": "CASH"
     },
     {
-      "id": 15,
+      "id": "15",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 40000,
       "category_id": 9,
       "detail": "영화 & 볼링",
       "memo": "친구들이랑",
-      "method": "CARD",
       "transacted_at": "2026-03-28T18:00:00.000Z",
-      "created_at": "2026-03-28T18:00:00.000Z"
+      "created_at": "2026-03-28T18:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 16,
+      "id": "16",
       "user_id": 1,
       "type": "INCOME",
       "amount": 3000000,
       "category_id": 11,
       "detail": "4월 급여",
       "memo": "",
-      "method": "TRANSFER",
       "transacted_at": "2026-04-01T09:00:00.000Z",
-      "created_at": "2026-04-01T09:00:00.000Z"
+      "created_at": "2026-04-01T09:00:00.000Z",
+      "payment": null
     },
     {
-      "id": 17,
+      "id": "17",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 12000,
       "category_id": 1,
       "detail": "점심 식사",
       "memo": "팀 점심",
-      "method": "CARD",
       "transacted_at": "2026-04-02T12:30:00.000Z",
-      "created_at": "2026-04-02T12:30:00.000Z"
+      "created_at": "2026-04-02T12:30:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 18,
+      "id": "18",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 4500,
       "category_id": 2,
       "detail": "아메리카노",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-04-03T08:45:00.000Z",
-      "created_at": "2026-04-03T08:45:00.000Z"
+      "created_at": "2026-04-03T08:45:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 19,
+      "id": "19",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 1500,
       "category_id": 3,
       "detail": "버스",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-04-04T07:30:00.000Z",
-      "created_at": "2026-04-04T07:30:00.000Z"
+      "created_at": "2026-04-04T07:30:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 20,
+      "id": "20",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 13900,
       "category_id": 6,
       "detail": "넷플릭스",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-04-05T00:00:00.000Z",
-      "created_at": "2026-04-05T00:00:00.000Z"
+      "created_at": "2026-04-05T00:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 21,
+      "id": "21",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 45000,
       "category_id": 5,
       "detail": "마트 장보기",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-04-06T16:00:00.000Z",
-      "created_at": "2026-04-06T16:00:00.000Z"
+      "created_at": "2026-04-06T16:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 22,
+      "id": "22",
       "user_id": 1,
       "type": "INCOME",
       "amount": 200000,
       "category_id": 12,
       "detail": "프리랜서 수입",
       "memo": "",
-      "method": "TRANSFER",
       "transacted_at": "2026-04-08T10:00:00.000Z",
-      "created_at": "2026-04-08T10:00:00.000Z"
+      "created_at": "2026-04-08T10:00:00.000Z",
+      "payment": null
     },
     {
-      "id": 23,
+      "id": "23",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 89000,
       "category_id": 4,
       "detail": "봄 옷 구매",
       "memo": "",
-      "method": "CARD",
       "transacted_at": "2026-04-09T14:00:00.000Z",
-      "created_at": "2026-04-09T14:00:00.000Z"
+      "created_at": "2026-04-09T14:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
-      "id": 24,
+      "id": "24",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 15000,
       "category_id": 7,
       "detail": "약국",
       "memo": "",
-      "method": "CASH",
       "transacted_at": "2026-04-10T11:00:00.000Z",
-      "created_at": "2026-04-10T11:00:00.000Z"
+      "created_at": "2026-04-10T11:00:00.000Z",
+      "payment": "CASH"
     },
     {
-      "id": 25,
+      "id": "25",
       "user_id": 1,
       "type": "EXPENSE",
       "amount": 32000,
       "category_id": 9,
       "detail": "영화 관람",
       "memo": "친구랑",
-      "method": "CARD",
       "transacted_at": "2026-04-11T19:00:00.000Z",
-      "created_at": "2026-04-11T19:00:00.000Z"
+      "created_at": "2026-04-11T19:00:00.000Z",
+      "payment": "CREDIT_CARD"
     },
     {
       "type": "EXPENSE",
+      "transacted_at": "2026-04-12T15:00:00.000Z",
       "amount": 1500,
-      "category_id": 3,
+      "category_id": "2",
       "detail": "버스",
-      "transacted_at": "2026-04-12T15:44:36.534Z",
-      "user_id": 1,
-      "id": 26
+      "memo": "",
+      "user_id": "1",
+      "id": "RvSsKzGQBDQ",
+      "displayTime": "00:44",
+      "created_at": "2026-04-12T19:19:41.167Z",
+      "payment": "EASY_PAY"
     },
     {
       "type": "EXPENSE",
       "transacted_at": "2026-04-12T00:00:00.000Z",
       "amount": 50000,
-      "category_id": 8,
+      "category_id": "8",
       "detail": "교육",
       "memo": "",
-      "method": "CARD",
       "created_at": "2026-04-12T15:45:15.557Z",
-      "user_id": 1,
-      "id": 27
+      "user_id": "1",
+      "id": "oZLDgG7UL-A",
+      "payment": "CREDIT_CARD"
     },
     {
       "type": "EXPENSE",
+      "transacted_at": "2026-04-12T00:00:00.000Z",
       "amount": 15000,
       "category_id": 7,
       "detail": "약국",
-      "transacted_at": "2026-04-12T15:45:25.665Z",
-      "user_id": 1,
-      "id": 28
+      "memo": "",
+      "user_id": "1",
+      "id": "lk2ttVNnWyE",
+      "displayTime": "00:45",
+      "created_at": "2026-04-12T19:19:08.211Z",
+      "payment": "CHECK_CARD"
     },
     {
       "type": "EXPENSE",
+      "transacted_at": "2026-04-12T00:00:00.000Z",
+      "amount": 3000,
+      "category_id": 3,
+      "detail": "버스",
+      "memo": "",
+      "created_at": "2026-04-12T18:13:07.960Z",
+      "user_id": "1",
+      "id": "qSKHVC8",
+      "displayTime": "02:29",
+      "payment": "CREDIT_CARD"
+    },
+    {
+      "type": "EXPENSE",
+      "transacted_at": "2026-04-12T00:00:00.000Z",
       "amount": 1500,
       "category_id": 3,
       "detail": "버스",
-      "transacted_at": "2026-04-12T17:29:02.259Z",
-      "user_id": 1,
-      "id": 29
+      "memo": "",
+      "user_id": "1",
+      "id": "8adBnYt",
+      "displayTime": "02:57",
+      "created_at": "2026-04-12T19:19:01.344Z",
+      "payment": "CREDIT_CARD"
+    },
+    {
+      "type": "INCOME",
+      "transacted_at": "2026-04-12T15:00:00.000Z",
+      "amount": 3000,
+      "category_id": "3",
+      "detail": "교통",
+      "memo": "",
+      "created_at": "2026-04-12T18:13:21.276Z",
+      "user_id": "1",
+      "id": "m2_ychF",
+      "displayTime": "09:00",
+      "payment": null
+    },
+    {
+      "type": "EXPENSE",
+      "transacted_at": "2026-04-12T15:00:00.000Z",
+      "amount": 3000,
+      "category_id": "6",
+      "detail": "구독",
+      "memo": "",
+      "created_at": "2026-04-12T19:22:22.978Z",
+      "user_id": "1",
+      "id": "uDGFmDL",
+      "payment": "CREDIT_CARD"
     }
   ],
   "$schema": "./node_modules/json-server/schema.json"

--- a/server/db.json
+++ b/server/db.json
@@ -16,5 +16,12 @@
     { "id": 13, "code": "INVESTMENT",   "name": "투자",   "type": "INCOME"  },
     { "id": 14, "code": "ALLOWANCE",    "name": "용돈",   "type": "INCOME"  },
     { "id": 15, "code": "ETC_INCOME",   "name": "기타",   "type": "INCOME"  }
+  ],
+  "payments": [
+    { "id": 1, "code": "CREDIT_CARD", "name": "신용카드" },
+    { "id": 2, "code": "CHECK_CARD", "name": "체크카드" },
+    { "id": 3, "code": "CASH", "name": "현금" },
+    { "id": 4, "code": "BANK_TRANSFER", "name": "계좌이체" },
+    { "id": 5, "code": "EASY_PAY", "name": "간편결제" }
   ]
 }

--- a/src/api/axiosClient.js
+++ b/src/api/axiosClient.js
@@ -144,6 +144,14 @@ async function getCategories() {
   return res.data;
 }
 
+async function getPayments() {
+  const res = await axios.get(`${urlPrefix}/payments`);
+
+  checkRequestFailed(res.status, ErrorCode.FETCH_FAILED);
+
+  return res.data;
+}
+
 async function getBudgets(userId) {
   const res = await axios.get(`${urlPrefix}/budgets`, {
     params: { user_id: userId },
@@ -192,10 +200,14 @@ const categoryApi = {
   getCategories,
 };
 
+const paymentApi = {
+  getPayments,
+};
+
 const budgetApi = {
   getBudgets,
   createBudget,
   updateBudget,
 };
 
-export default { memberApi, transactionApi, categoryApi, budgetApi };
+export default { memberApi, transactionApi, categoryApi, paymentApi, budgetApi };

--- a/src/api/services/paymentMethodService.js
+++ b/src/api/services/paymentMethodService.js
@@ -1,0 +1,9 @@
+import axiosClient from "@/api/axiosClient";
+import { enrichPaymentMethod } from "@/constant/paymentMethods";
+
+export const paymentMethodService = {
+  async fetchAll() {
+    const paymentMethods = await axiosClient.paymentApi.getPayments();
+    return paymentMethods.map(enrichPaymentMethod);
+  },
+};

--- a/src/components/transaction/TransactionAddModal.vue
+++ b/src/components/transaction/TransactionAddModal.vue
@@ -1,27 +1,22 @@
 <script setup>
-import { ref, computed } from "vue";
+import { computed } from "vue";
+import { storeToRefs } from "pinia";
 import { useAddTransactionStore } from "@/stores/transactions/useAddTransactionStore";
 import { useCategoryStore } from "@/stores/categories/useCategoryStore";
-import { Payments } from "../../constant/paymentMethods";
+import { usePaymentMethodStore } from "@/stores/payments/usePaymentMethodStore";
 import { DatePicker } from "v-calendar";
 import "v-calendar/style.css";
 
 const addTransactionStore = useAddTransactionStore();
 const categoryStore = useCategoryStore();
+const paymentMethodStore = usePaymentMethodStore();
+const { paymentMethods } = storeToRefs(paymentMethodStore);
 const formData = addTransactionStore.formData;
 
 const categorizedList = computed(() => {
   return {
     INCOME: categoryStore.categories.filter((cat) => cat.type === "INCOME"),
     EXPENSE: categoryStore.categories.filter((cat) => cat.type === "EXPENSE"),
-  };
-});
-
-const paymentMethods = computed(() => {
-  const allList = Object.values(Payments);
-
-  return {
-    ALL: allList,
   };
 });
 
@@ -43,6 +38,9 @@ const handleSubmit = () => {
   }
   if (!formData.detail) {
     formData.detail = categoryStore.getCategoryById(formData.category_id)?.name;
+  }
+  if (formData.type !== 'EXPENSE') {
+    formData.payment = null;
   }
   addTransactionStore.submitTransaction();
 };
@@ -173,15 +171,15 @@ const handleSubmit = () => {
               </div>
             </div>
 
-            <div class="form-group">
+            <div class="form-group" v-if="formData.type === 'EXPENSE'">
               <label class="form-label">결제 수단</label>
               <div class="pills-container">
                 <div
-                  v-for="method in paymentMethods.ALL"
+                  v-for="method in paymentMethods"
                   :key="method.id"
                   class="pill-item"
-                  :class="{ selected: method.value == formData.method }"
-                  @click="formData.method = method.value"
+                  :class="{ selected: method.code === formData.payment }"
+                  @click="formData.payment = method.code"
                 >
                   {{ method.name }}
                 </div>

--- a/src/components/transaction/TransactionItem.vue
+++ b/src/components/transaction/TransactionItem.vue
@@ -1,10 +1,9 @@
 <script setup>
 import { ref } from "vue";
-import { storeToRefs } from "pinia";
 import { useCategoryStore } from "@/stores/categories/useCategoryStore";
 import { useAddTransactionStore } from "@/stores/transactions/useAddTransactionStore";
+import { usePaymentMethodStore } from "@/stores/payments/usePaymentMethodStore";
 import { formatAmountShort } from "@/utils/formatter";
-import { Payments } from "@/constant/paymentMethods";
 
 const props = defineProps({
   item: { type: Object, required: true },
@@ -13,6 +12,7 @@ const props = defineProps({
 const emit = defineEmits(["request-delete"]);
 
 const { getCategoryById } = useCategoryStore();
+const { getPaymentMethodByCode } = usePaymentMethodStore();
 const getCat = (id) => getCategoryById(id);
 
 const { openEditModal } = useAddTransactionStore();
@@ -34,8 +34,7 @@ const formatExpandDate = (dateStr, time) => {
   return `${d.getMonth() + 1}월 ${d.getDate()}일 ${time}`;
 };
 
-const getPayment = (method) =>
-  Object.values(Payments).find((p) => p.value === method);
+const getPayment = (method) => getPaymentMethodByCode(method);
 </script>
 
 <template>
@@ -137,14 +136,14 @@ const getPayment = (method) =>
               {{ formatAmount(item.amount, item.type) }}
             </span>
           </div>
-          <div class="expand-row" v-if="item.method">
+          <div class="expand-row" v-if="item.payment">
             <span class="expand-label">결제수단</span>
             <span class="expand-value">
               <i
-                :class="getPayment(item.method)?.icon"
-                :style="{ color: getPayment(item.method)?.color }"
+                :class="getPayment(item.payment)?.icon"
+                :style="{ color: getPayment(item.payment)?.color }"
               ></i>
-              {{ getPayment(item.method)?.name ?? item.method }}
+              {{ getPayment(item.payment)?.name ?? item.payment }}
             </span>
           </div>
           <div class="expand-row" v-if="item.memo">

--- a/src/components/transaction/TransactionQuickAddModal.vue
+++ b/src/components/transaction/TransactionQuickAddModal.vue
@@ -56,6 +56,8 @@ const proceedAdd = async () => {
     amount: confirmingItem.value.amount,
     category_id: confirmingItem.value.category_id,
     detail: confirmingItem.value.detail,
+    memo: confirmingItem.value.memo ?? "",
+    payment: confirmingItem.value.payment ?? "CREDIT_CARD",
     transacted_at: new Date().toISOString(), // 날짜/시간은 현재 시점으로 갱신
   };
 

--- a/src/constant/paymentMethods.js
+++ b/src/constant/paymentMethods.js
@@ -1,42 +1,38 @@
-export const Payments = {
+export const PAYMENT_METHOD_UI = {
   CREDIT_CARD: {
-    id: "method01",
-    value: "CREDIT_CARD",
-    name: "신용카드",
     color: "#1E90FF",
     subColor: "#E1F5FE",
     icon: "fa-solid fa-credit-card",
   },
   CHECK_CARD: {
-    id: "method02",
-    value: "CHECK_CARD",
-    name: "체크카드",
     color: "#00CED1",
     subColor: "#E0F7FA",
     icon: "fa-solid fa-wallet",
   },
   CASH: {
-    id: "method03",
-    value: "CASH",
-    name: "현금",
     color: "#2ECC71",
     subColor: "#E8F5E9",
     icon: "fa-solid fa-money-bill-wave",
   },
   BANK_TRANSFER: {
-    id: "method04",
-    value: "TRANSFER",
-    name: "계좌이체",
     color: "#9B59B6",
     subColor: "#F3E5F5",
     icon: "fa-solid fa-building-columns",
   },
   EASY_PAY: {
-    id: "method05",
-    value: "MOBILE",
-    name: "간편결제",
     color: "#F39C12",
     subColor: "#FFF3E0",
     icon: "fa-solid fa-mobile-screen-button",
   },
 };
+
+export const DEFAULT_PAYMENT_METHOD_UI = {
+  color: "#808080",
+  subColor: "#F3F4F6",
+  icon: "fa-solid fa-money-check",
+};
+
+export const enrichPaymentMethod = (method) => ({
+  ...method,
+  ...(PAYMENT_METHOD_UI[method.code] ?? DEFAULT_PAYMENT_METHOD_UI),
+});

--- a/src/layouts/LedgerLayout.vue
+++ b/src/layouts/LedgerLayout.vue
@@ -7,10 +7,12 @@ import TransactionAddModal from '@/components/transaction/TransactionAddModal.vu
 import TransactionQuickAddModal from '@/components/transaction/TransactionQuickAddModal.vue';
 import { useAddTransactionStore } from '@/stores/transactions/useAddTransactionStore';
 import { useCategoryStore } from '@/stores/categories/useCategoryStore';
+import { usePaymentMethodStore } from '@/stores/payments/usePaymentMethodStore';
 import { ref, onMounted } from 'vue';
 
 onMounted(() => {
   useCategoryStore().fetchCategories();
+  usePaymentMethodStore().fetchPaymentMethods();
 });
 
 const isFabOpen = ref(false);

--- a/src/stores/payments/usePaymentMethodStore.js
+++ b/src/stores/payments/usePaymentMethodStore.js
@@ -1,0 +1,27 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { paymentMethodService } from "@/api/services/paymentMethodService";
+import { DEFAULT_PAYMENT_METHOD_UI } from "@/constant/paymentMethods";
+
+export const usePaymentMethodStore = defineStore("paymentMethod", () => {
+  const paymentMethods = ref([]);
+
+  async function fetchPaymentMethods() {
+    try {
+      paymentMethods.value = await paymentMethodService.fetchAll();
+    } catch (error) {
+      console.error("결제수단 조회 실패:", error);
+    }
+  }
+
+  function getPaymentMethodByCode(code) {
+    return (
+      paymentMethods.value.find((method) => method.code === code) ?? {
+        code,
+        ...DEFAULT_PAYMENT_METHOD_UI,
+      }
+    );
+  }
+
+  return { paymentMethods, fetchPaymentMethods, getPaymentMethodByCode };
+});

--- a/src/stores/transactions/useAddTransactionStore.js
+++ b/src/stores/transactions/useAddTransactionStore.js
@@ -16,7 +16,7 @@ export const useAddTransactionStore = defineStore("addTransaction", () => {
     category_id: "",
     detail: "",
     memo: "",
-    method: "CARD",
+    payment: "CREDIT_CARD",
   };
 
   const formData = reactive({ ...initialFormState });


### PR DESCRIPTION
## Summary

- 결제수단을 클라이언트 상수가 아닌 서버(`/payments`)에서 fetch하도록 변경
- 거래 데이터의 결제수단 필드명 `method` → `payment` 로 변경
- EXPENSE 거래에서만 결제수단 선택 UI 노출, INCOME 거래는 `payment: null` 로 저장
- `usePaymentMethodStore` 추가 및 `paymentMethodService` API 레이어 추가

Closes #112

## Test plan

- [ ] 지출 거래 추가 시 결제수단 선택 UI 노출 확인
- [ ] 수입 거래 추가 시 결제수단 선택 UI 미노출 확인
- [ ] 수입 거래 저장 후 `payment` 필드가 `null` 인지 확인
- [ ] 결제수단 목록이 서버에서 정상 fetch 되는지 확인
- [ ] 거래 수정 모드에서 결제수단 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)